### PR TITLE
Trigger key migration screen when necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.2.0",
         "@nimiq/rpc": "^0.3.0",
-        "@nimiq/style": "^0.7.0",
+        "@nimiq/style": "^0.7.1",
         "@nimiq/utils": "^0.3.2",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.6.6",

--- a/public/blocking.css
+++ b/public/blocking.css
@@ -133,12 +133,6 @@ body {
     100% { stroke-dashoffset: 165.5 }
 }
 
-@media (max-width: 450px) {
-    html {
-        font-size: 7px;
-    }
-}
-
 /* Mobile Layout */
 
 @media (max-width: 450px) {

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -30,7 +30,7 @@ class IFrameApi {
         }
 
         // If no wallets exist, see if the Keyguard has keys
-        const client = new (await import('@nimiq/keyguard-client')).KeyguardClient();
+        const client = new (await import('@nimiq/keyguard-client')).KeyguardClient(Config.keyguardEndpoint);
         const hasKeys = await client.hasKeys();
         if (hasKeys.success) {
             throw new Error('ACCOUNTS_LOST');

--- a/src/lib/AccountInfo.ts
+++ b/src/lib/AccountInfo.ts
@@ -20,6 +20,7 @@ export class AccountInfo {
     }
 
     public walletId?: string;
+    public isBackedUp?: boolean; /* Used for pre-migration  */
 
     public constructor(
         public path: string,

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -171,8 +171,8 @@ export default class RpcApi {
 
                 const wallets = await WalletStore.Instance.list();
                 if (!wallets.length) {
-                    const hasLegacyAccounts = await this._keyguardClient.hasLegacyAccounts();
-                    if (hasLegacyAccounts.success) {
+                    const hasLegacyAccounts = (await this._keyguardClient.hasLegacyAccounts()).success;
+                    if (hasLegacyAccounts) {
                         // Keyguard has legacy accounts, redirect to migration
                         if (requestType !== RequestType.MIGRATE) {
                             this._staticStore.originalRouteName = requestType;

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -174,7 +174,6 @@ export default class RpcApi {
                     const hasLegacyAccounts = await this._keyguardClient.hasLegacyAccounts();
                     if (hasLegacyAccounts.success) {
                         // Keyguard has legacy accounts, redirect to migration
-                        migrationRequired = true;
                         if (requestType !== RequestType.MIGRATE) {
                             this._staticStore.originalRouteName = requestType;
                         }

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -178,6 +178,7 @@ export default class RpcApi {
                             this._staticStore.originalRouteName = requestType;
                         }
                         this.routerReplace(RequestType.MIGRATE);
+                        this._startRoute();
                         return;
                     }
                 }

--- a/src/views/ExportSuccess.vue
+++ b/src/views/ExportSuccess.vue
@@ -14,7 +14,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage, CheckmarkIcon } from '@nimiq/vue-components';
-import { ParsedSimpleRequest } from '../lib/RequestTypes';
+import { ParsedSimpleRequest, RequestType } from '../lib/RequestTypes';
 import { ExportResult } from '../lib/PublicRequestTypes';
 import { State } from 'vuex-class';
 import { Static } from '@/lib/StaticStore';
@@ -26,12 +26,18 @@ import KeyguardClient from '@nimiq/keyguard-client';
 @Component({components: {SmallPage, Loader, CheckmarkIcon}})
 export default class ExportSuccess extends Vue {
     @Static private request!: ParsedSimpleRequest;
+    @Static private originalRouteName?: string;
     @State private keyguardResult!: KeyguardClient.ExportResult;
 
     private loaderState = Loader.State.LOADING;
     private successMessage = '';
 
     private async mounted() {
+        if (this.originalRouteName || this.request.kind === RequestType.MIGRATE) {
+            this.$rpc.routerReplace(RequestType.MIGRATE);
+            return;
+        }
+
         const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
 
         wallet.fileExported = wallet.fileExported || this.keyguardResult.fileExported;

--- a/src/views/ExportSuccess.vue
+++ b/src/views/ExportSuccess.vue
@@ -82,7 +82,7 @@ export default class ExportSuccess extends Vue {
             // We want the RpcApi's reply method to only be invoked when migration is finished.
 
             // Recreate original URL with original query parameters
-            const query = { id: staticStore.rpcState!.id.toString() };
+            const query = { rpcId: staticStore.rpcState!.id.toString() };
             setTimeout(
                 () => this.$router.push({ name: RequestType.MIGRATE, query }), Loader.SUCCESS_REDIRECT_DELAY);
         }

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -115,7 +115,7 @@ import { ContractInfo } from '@/lib/ContractInfo';
 import staticStore, { Static } from '@/lib/StaticStore';
 import { SimpleRequest } from '@/lib/PublicRequestTypes';
 import { State } from 'vuex-class';
-import { RequestType } from '../lib/RequestTypes';
+import { RequestType } from '@/lib/RequestTypes';
 
 type SerializedAccount = {
     path: string;
@@ -139,7 +139,7 @@ export default class Migrate extends Vue {
     private page: 'intro' | 'accounts' | 'migration' = 'intro';
     private backupsAreSafe: boolean = false;
 
-    private title: string = 'Migrating your accounts';
+    private title: string = 'Updating your Accounts';
     private status: string = 'Connecting to Keyguard...';
     private state: Loader.State = Loader.State.LOADING;
     private message: string = '';
@@ -216,12 +216,12 @@ export default class Migrate extends Vue {
     private async doMigration() {
         this.page = 'migration';
 
-        this.status = 'Retrieving your legacy accounts...';
+        this.status = 'Retrieving your old Accounts...';
         const legacyAccounts = await this.$rpc.keyguardClient.listLegacyAccounts();
 
         if (!legacyAccounts.length) {
             this.deleteAccountsCache();
-            this.title = 'Nothing to migrate.';
+            this.title = 'Nothing to update.';
             this.state = Loader.State.SUCCESS;
             setTimeout(() => this.$rpc.resolve([]), Loader.SUCCESS_REDIRECT_DELAY);
             return;
@@ -230,7 +230,7 @@ export default class Migrate extends Vue {
         this.status = 'Detecting vesting contracts...';
         const genesisVestingContracts = await (this.$refs.network as Network).getGenesisVestingContracts();
 
-        this.status = 'Storing your accounts...';
+        this.status = 'Storing your new Accounts...';
         // For the wallet ID derivation to work, the ID derivation and storing of new wallets needs
         // to happen serially, e.g. synchroneous.
         const walletInfos: WalletInfo[] = [];
@@ -259,11 +259,11 @@ export default class Migrate extends Vue {
             walletInfos.push(walletInfo);
         }
 
-        this.status = 'Migrating Keyguard...';
+        this.status = 'Updating Keyguard...';
         await this.$rpc.keyguardClient.migrateAccountsToKeys();
         this.deleteAccountsCache();
 
-        this.title = 'Migration completed.';
+        this.title = 'Accounts updated!';
         this.state = Loader.State.SUCCESS;
         const listResult = walletInfos.map((walletInfo) => walletInfo.toAccountType());
         setTimeout(() => this.$rpc.resolve(listResult), Loader.SUCCESS_REDIRECT_DELAY);
@@ -279,7 +279,7 @@ export default class Migrate extends Vue {
     }
 
     private tryAgain() {
-        this.title = 'Migrating your accounts';
+        this.title = 'Updating your Accounts';
         this.status = 'Connecting to Keyguard...';
         this.state = Loader.State.LOADING;
         setTimeout(() => this.runMigration(), 1000);

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -38,7 +38,7 @@
                 </a>
             </PageBody>
 
-            <PageFooter>
+            <PageFooter key="intro-footer">
                 <button class="nq-button light-blue" @click="page = 'accounts'">Prepare for update</button>
             </PageFooter>
         </SmallPage>
@@ -69,7 +69,7 @@
                 </div>
             </PageBody>
 
-            <PageFooter>
+            <PageFooter key="accounts-footer">
                 <transition name="transition-fade" mode="out-in">
                     <div v-if="!backupsAreSafe" class="nq-light-blue-bg check-box">
                         <label>
@@ -561,26 +561,5 @@ export default class Migrate extends Vue {
     .transition-fade-enter,
     .transition-fade-leave-to {
         opacity: 0;
-    }
-
-    /*
-    Because Vue does virtual-DOM diffing, pages are not replaced as complete components but rather
-    parts of the pages are replaced, e.g. the footer content (while the footer element itself
-    stays the same).
-
-    This has a negative visual effect on the check-box, because it has a transition applied
-    which fades it out when it is de-rendered. Because of the DOM-diffing instead of full element
-    replacing, the check-box is rendered fading-out next to the intro page's "Prepare for update"
-    button when clicking on the back arrow.
-
-    These styles here prevent that from happening by force-hiding them.
-
-    If you know a better method to force Vue to throw out an element instead of fading it out,
-    please make yourself known.
-    */
-    .intro .check-box,
-    .intro .activate {
-        display: none;
-        transition: none;
     }
 </style>

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -1,17 +1,45 @@
 <template>
     <div class="container pad-bottom">
-        <SmallPage v-if="!isMigrating">
-            <div class="page-header nq-card-header">
-                <h1 class="nq-h1">We've updated!</h1>
-                <p class="nq-notice info">
-                    The new Nimiq Keyguard requires a database update.
+        <Network ref="network" :visible="false"/>
+        <SmallPage v-if="page === 'intro'" class="intro">
+            <PageHeader>
+                Time to grow
+                <p slot="more" class="nq-notice info">
+                    Nimiq just got better! New UX and UI come with a batch of new features.
                 </p>
-                <p class="nq-text">
-                    To refresh your backups before we update,<br>select an account below.
-                </p>
-            </div>
+            </PageHeader>
 
+            <PageBody>
+                <div class="topic">
+                    <div class="topic-visual account-ring"></div>
+                    <p class="topic-copy">
+                        One Account can now have multiple Addresses.
+                    </p>
+                </div>
+                <div class="topic">
+                    <p class="topic-copy">
+                        Nimiq implements the ImageWallet standard with the Nimiq Login File.
+                    </p>
+                    <div class="topic-visual login-file"></div>
+                </div>
+                <div class="topic">
+                    <div class="topic-visual qr-code"></div>
+                    <p class="topic-copy">
+                        Create and scan QR codes to quickly share Addresses.
+                    </p>
+                </div>
 
+                <a href="https://medium.com/nimiq-network" target="_blank" class="nq-link link-read-article">
+                    ...and much more. Read the full article <ArrowRightIcon/>
+                </a>
+            </PageBody>
+
+            <PageFooter>
+                <button class="nq-button light-blue" @click="page = 'accounts'">Prepare for update</button>
+            </PageFooter>
+        </SmallPage>
+
+        <SmallPage v-else-if="page === 'accounts'">
             <AccountList
                 walletId="unused"
                 :accounts="legacyAccounts"
@@ -31,7 +59,6 @@
                 mainAction="Try again"
                 @main-action="tryAgain"
             />
-            <Network ref="network" :visible="false"/>
         </SmallPage>
     </div>
 </template>
@@ -41,7 +68,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import { AccountInfo } from '@/lib/AccountInfo';
 import { WalletStore } from '@/lib/WalletStore';
 import { WalletInfo, WalletType } from '@/lib/WalletInfo';
-import { SmallPage, PageHeader, PageBody, PageFooter, AccountList } from '@nimiq/vue-components';
+import { SmallPage, PageHeader, PageBody, PageFooter, AccountList, ArrowRightIcon } from '@nimiq/vue-components';
 import Network from '@/components/Network.vue';
 import Loader from '@/components/Loader.vue';
 import KeyguardClient from '@nimiq/keyguard-client';
@@ -50,9 +77,11 @@ import { ContractInfo } from '@/lib/ContractInfo';
 import { Static } from '@/lib/StaticStore';
 import { SimpleRequest } from '@/lib/PublicRequestTypes';
 
-@Component({components: {SmallPage, PageHeader, PageBody, PageFooter, AccountList, Loader, Network}})
+@Component({components: {SmallPage, PageHeader, PageBody, PageFooter, AccountList, ArrowRightIcon, Loader, Network}})
 export default class Migrate extends Vue {
     @Static private request!: SimpleRequest;
+
+    private page: 'intro' | 'accounts' | 'migration' = 'intro';
 
     private title: string = 'Migrating your accounts';
     private status: string = 'Connecting to Keyguard...';
@@ -99,7 +128,6 @@ export default class Migrate extends Vue {
 
         this.status = 'Detecting vesting contracts...';
         const genesisVestingContracts = await (this.$refs.network as Network).getGenesisVestingContracts();
-        (this.$refs.network as Network).disconnect(); // Prevent syncing consensus
 
         this.status = 'Storing your new accounts...';
         // For the wallet ID derivation to work, the ID derivation and storing of new wallets needs
@@ -163,7 +191,71 @@ export default class Migrate extends Vue {
 </script>
 
 <style>
-    .page-header {
-        padding-bottom: 0;
+    .intro .page-body {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        padding-left: 5rem;
+        padding-right: 5rem;
+    }
+
+    .topic {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .topic-visual {
+        flex-shrink: 0;
+        width: 8rem;
+        height: 8rem;
+        border-radius: .5rem;
+        background: rgba(0, 0, 0, 0.05);
+        margin-top: -1rem;
+        margin-bottom: -1rem;
+        margin-right: 3rem;
+    }
+
+    .topic-copy {
+        margin: 0;
+        font-size: 2rem;
+        line-height: 1.3;
+    }
+
+    .topic-copy + .topic-visual {
+        margin-right: 0;
+        margin-left: 3rem;
+    }
+
+    .topic-visual.login-file {
+        width: 6.875rem;
+        height: 11.75rem;
+        margin-top: -2.875rem;
+        margin-bottom: -2.875rem;
+    }
+
+    .link-read-article {
+        font-size: 2rem;
+        font-weight: bold;
+        align-self: center;
+    }
+
+    .link-read-article .nq-icon {
+        vertical-align: middle;
+        width: 1.375rem;
+        height: 1.125rem;
+        margin-top: -0.125rem;
+        transition: transform .3s cubic-bezier(0.25, 0, 0, 1);
+    }
+
+    .link-read-article:hover .nq-icon,
+    .link-read-article:focus .nq-icon {
+        transform: translate3D(0.25rem, 0, 0);
+    }
+
+    .page-footer .nq-button {
+        margin-top: 1rem;
+        margin-bottom: 3rem;
+        width: calc(100% - 10rem);
     }
 </style>

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -14,12 +14,12 @@
                     <div class="topic-visual account-ring">
                         <AccountRing :addresses="['NQ18 37VM K2Y5 2HPY 5U80 2E0U VHUJ R7RK QSNE', 'NQ81 K7NT 9TJA BXE8 5D0R 3FN4 QJK0 YVYQ YD9A', 'NQ90 277A GR05 F775 AVFK 61RP CS7Y R7JA KGCT']"/>
                     </div>
-                    <p class="topic-copy">
+                    <p class="topic-text">
                         One Account can now have multiple Addresses.
                     </p>
                 </div>
                 <div class="topic">
-                    <p class="topic-copy">
+                    <p class="topic-text">
                         Nimiq implements the ImageWallet standard with the Nimiq Login File.
                     </p>
                     <div class="topic-visual login-file">
@@ -28,13 +28,13 @@
                 </div>
                 <div class="topic">
                     <div class="topic-visual qr-code"><ScanQrCodeIcon/></div>
-                    <p class="topic-copy">
+                    <p class="topic-text">
                         Create and scan QR codes to quickly share Addresses.
                     </p>
                 </div>
 
                 <a href="https://medium.com/nimiq-network" target="_blank" class="nq-link link-read-article">
-                    ...and much more. Read the full article <ArrowRightSmallIcon/>
+                    There's much more. Read the full article <ArrowRightSmallIcon/>
                 </a>
             </PageBody>
 
@@ -356,13 +356,13 @@ export default class Migrate extends Vue {
         margin-right: 3rem;
     }
 
-    .topic-copy {
+    .topic-text {
         margin: 0;
         font-size: 2rem;
         line-height: 1.3;
     }
 
-    .topic-copy + .topic-visual {
+    .topic-text + .topic-visual {
         margin-right: 0;
         margin-left: 2rem; /* Less than the right margin, to fit in Firefox */
     }

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -11,7 +11,9 @@
 
             <PageBody>
                 <div class="topic">
-                    <div class="topic-visual account-ring"></div>
+                    <div class="topic-visual account-ring">
+                        <AccountRing :addresses="['NQ18 37VM K2Y5 2HPY 5U80 2E0U VHUJ R7RK QSNE', 'NQ81 K7NT 9TJA BXE8 5D0R 3FN4 QJK0 YVYQ YD9A', 'NQ90 277A GR05 F775 AVFK 61RP CS7Y R7JA KGCT']"/>
+                    </div>
                     <p class="topic-copy">
                         One Account can now have multiple Addresses.
                     </p>
@@ -20,17 +22,19 @@
                     <p class="topic-copy">
                         Nimiq implements the ImageWallet standard with the Nimiq Login File.
                     </p>
-                    <div class="topic-visual login-file"></div>
+                    <div class="topic-visual login-file">
+                        <svg width="58" height="97" viewBox="0 0 58 97" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x=".59" y=".78" width="56.81" height="95.45" rx="2.78" fill="#fff"/><path d="M1.67 3.7c0-1.01.83-1.84 1.85-1.84h50.95c1.02 0 1.85.83 1.85 1.85v89.58c0 1.02-.83 1.85-1.85 1.85H3.52a1.85 1.85 0 0 1-1.85-1.85V3.71z" fill="url(#paint0_radial)"/><g opacity=".5" fill="#fff"><g clip-path="url(#clip0)"><path d="M15.87 10.5l-1.02-1.77a.4.4 0 0 0-.35-.2h-2.03a.4.4 0 0 0-.35.2l-1.01 1.76a.4.4 0 0 0 0 .4l1.01 1.77c.08.13.21.2.35.2h2.03a.4.4 0 0 0 .35-.2l1.02-1.76a.4.4 0 0 0 0-.4z"/><rect x="17.26" y="9.14" width="12.12" height="3.03" rx="1.51"/><rect x="30.89" y="9.14" width="15.15" height="3.03" rx="1.51"/></g><rect x="21.8" y="16.52" width="14.39" height="1.51" rx=".76"/></g><g opacity=".5" fill="#fff"><path fill-rule="evenodd" clip-rule="evenodd" d="M23.47 67.02h-6.62c-.61 0-1.1-.5-1.1-1.1v-6.63c0-.61.49-1.1 1.1-1.1h6.62c.62 0 1.11.49 1.11 1.1v6.63c0 .6-.5 1.1-1.1 1.1zm-5.24-6.63a.28.28 0 0 0-.28.28v3.86c0 .16.13.28.28.28h3.86c.16 0 .28-.12.28-.28v-3.86a.28.28 0 0 0-.28-.28h-3.86zM16.85 75.86h6.62c.61 0 1.1.5 1.1 1.1v6.63c0 .6-.49 1.1-1.1 1.1h-6.62c-.61 0-1.1-.49-1.1-1.1v-6.63c0-.6.49-1.1 1.1-1.1zm5.24 6.62c.16 0 .28-.12.28-.27v-3.87a.28.28 0 0 0-.28-.27h-3.86a.28.28 0 0 0-.28.27v3.87c0 .15.13.27.28.27h3.86zM34.52 58.18h6.63c.6 0 1.1.5 1.1 1.1v6.64c0 .6-.5 1.1-1.1 1.1h-6.63c-.6 0-1.1-.5-1.1-1.1v-6.63c0-.61.5-1.1 1.1-1.1zm5.25 6.63c.15 0 .27-.12.27-.28v-3.86a.28.28 0 0 0-.27-.28H35.9a.28.28 0 0 0-.27.28v3.86c0 .16.12.28.27.28h3.87z"/><path d="M26.79 62.88h1.1a.83.83 0 1 0 0-1.66.28.28 0 0 1-.27-.28V59.3a.83.83 0 0 0-1.66 0v2.76c0 .46.37.83.83.83zM30.1 60.12c.16 0 .28.12.28.27v6.08a.83.83 0 0 0 1.66 0v-7.18a.83.83 0 0 0-.83-.83h-1.1a.83.83 0 0 0 0 1.66zM22.1 69.78c0 .46.36.83.82.83h3.87c.46 0 .83-.37.83-.83v-4.42a.83.83 0 0 0-1.66 0v3.32c0 .15-.12.27-.28.27h-2.76a.83.83 0 0 0-.83.83z"/><path d="M19.06 68.95a.83.83 0 0 0-.83.83v2.76c0 .16-.13.28-.28.28h-1.1a.83.83 0 0 0 0 1.66H31.2c.45 0 .83-.37.83-.83v-3.32a.83.83 0 0 0-1.66 0v2.21c0 .16-.13.28-.28.28h-9.94a.28.28 0 0 1-.28-.28v-2.76a.83.83 0 0 0-.82-.83zM30.93 76.96a.83.83 0 0 0-.83-.83H26.8a.83.83 0 0 0-.83.83v4.42a.83.83 0 0 0 1.66 0v-3.31c0-.16.12-.28.27-.28h2.21c.46 0 .83-.37.83-.83zM41.15 82.76h-9.39a.28.28 0 0 1-.28-.28v-2.2a.83.83 0 0 0-1.65 0v3.31c0 .46.37.83.82.83h10.5a.83.83 0 1 0 0-1.66z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M37.28 80.55h-3.31a.83.83 0 0 1-.83-.83v-3.31c0-.46.37-.83.83-.83h3.31c.46 0 .83.37.83.83v3.31c0 .46-.37.83-.83.83zm-2.2-3.31a.28.28 0 0 0-.28.27v1.1c0 .16.12.28.27.28h1.1c.16 0 .28-.12.28-.27v-1.1a.28.28 0 0 0-.27-.28h-1.1z"/><path d="M40.6 72.27a.83.83 0 0 0-.83.83v7.18a.83.83 0 1 0 1.66 0V73.1a.83.83 0 0 0-.83-.83zM41.43 69.23a.83.83 0 0 0-.83-.83h-6.08a.83.83 0 0 0-.83.83v3.31a.83.83 0 1 0 1.66 0v-2.2c0-.16.12-.28.28-.28h4.97c.45 0 .83-.37.83-.83z"/></g><g opacity=".35" fill="#fff"><path opacity=".7" d="M32.29 29.4l-1.57-2.72a.63.63 0 0 0-.54-.31h-3.14a.63.63 0 0 0-.54.31l-1.57 2.72a.63.63 0 0 0 0 .62l1.57 2.72c.11.2.32.31.54.31h3.14c.22 0 .43-.12.54-.31l1.57-2.72a.62.62 0 0 0 0-.62z"/><path opacity=".78" d="M32.29 45.2l-1.57-2.72a.63.63 0 0 0-.54-.31h-3.14a.63.63 0 0 0-.54.3l-1.57 2.72a.63.63 0 0 0 0 .63l1.57 2.72c.11.2.32.31.54.31h3.14c.22 0 .43-.12.54-.31l1.57-2.72a.62.62 0 0 0 0-.63z"/><path opacity=".5" d="M25.45 33.35l-1.57-2.72a.63.63 0 0 0-.54-.31h-3.13a.63.63 0 0 0-.54.31l-1.57 2.72a.63.63 0 0 0 0 .62l1.56 2.72c.12.2.32.31.55.31h3.13c.22 0 .43-.12.54-.31l1.57-2.72a.63.63 0 0 0 0-.62z"/><path opacity=".6" d="M25.45 41.24l-1.57-2.71a.63.63 0 0 0-.54-.31h-3.13a.63.63 0 0 0-.54.3l-1.57 2.72a.63.63 0 0 0 0 .63l1.56 2.72c.12.2.32.31.55.31h3.13c.22 0 .43-.12.54-.31l1.57-2.72a.63.63 0 0 0 0-.63z"/><path opacity=".8" d="M39.12 33.35l-1.56-2.72a.63.63 0 0 0-.55-.31h-3.13a.63.63 0 0 0-.54.31l-1.57 2.72a.63.63 0 0 0 0 .62l1.57 2.72c.1.2.32.31.54.31h3.13c.23 0 .43-.12.54-.31l1.57-2.72a.62.62 0 0 0 0-.62z"/><path opacity=".6" d="M39.12 41.24l-1.56-2.71a.63.63 0 0 0-.55-.31h-3.13a.63.63 0 0 0-.54.3l-1.57 2.72a.63.63 0 0 0 0 .63l1.57 2.72c.1.2.32.31.54.31H37c.23 0 .43-.12.54-.31l1.57-2.72a.62.62 0 0 0 0-.63z"/></g><defs><radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-54.6465 0 0 -93.2842 56.32 95.14)"><stop stop-color="#EC991C"/><stop offset="1" stop-color="#E9B213"/></radialGradient><clipPath id="clip0"><path fill="#fff" transform="translate(11.05 8.53)" d="M0 0h35.81v4.33H0z"/></clipPath></defs></svg>
+                    </div>
                 </div>
                 <div class="topic">
-                    <div class="topic-visual qr-code"></div>
+                    <div class="topic-visual qr-code"><ScanQrCodeIcon/></div>
                     <p class="topic-copy">
                         Create and scan QR codes to quickly share Addresses.
                     </p>
                 </div>
 
                 <a href="https://medium.com/nimiq-network" target="_blank" class="nq-link link-read-article">
-                    ...and much more. Read the full article <ArrowRightIcon/>
+                    ...and much more. Read the full article <ArrowRightSmallIcon/>
                 </a>
             </PageBody>
 
@@ -92,8 +96,8 @@ import { WalletStore } from '@/lib/WalletStore';
 import { WalletInfo, WalletType } from '@/lib/WalletInfo';
 import {
     SmallPage, PageHeader, PageBody, PageFooter,
-    Identicon, Amount,
-    ArrowRightIcon, CheckmarkIcon,
+    AccountRing, Identicon, Amount,
+    ScanQrCodeIcon, ArrowRightSmallIcon, CheckmarkIcon,
 } from '@nimiq/vue-components';
 import Network from '@/components/Network.vue';
 import Loader from '@/components/Loader.vue';
@@ -105,14 +109,14 @@ import { SimpleRequest } from '@/lib/PublicRequestTypes';
 
 @Component({components: {
     SmallPage, PageHeader, PageBody, PageFooter,
-    Identicon, Amount,
-    ArrowRightIcon, CheckmarkIcon,
+    AccountRing, Identicon, Amount,
+    ScanQrCodeIcon, ArrowRightSmallIcon, CheckmarkIcon,
     Loader, Network,
 }})
 export default class Migrate extends Vue {
     @Static private request!: SimpleRequest;
 
-    private page: 'intro' | 'accounts' | 'migration' = 'accounts';
+    private page: 'intro' | 'accounts' | 'migration' = 'intro';
     private backupsAreSafe: boolean = false;
 
     private title: string = 'Migrating your accounts';
@@ -221,7 +225,7 @@ export default class Migrate extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
     .intro .page-body {
         display: flex;
         flex-direction: column;
@@ -241,7 +245,6 @@ export default class Migrate extends Vue {
         width: 8rem;
         height: 8rem;
         border-radius: .5rem;
-        background: rgba(0, 0, 0, 0.05);
         margin-top: -1rem;
         margin-bottom: -1rem;
         margin-right: 3rem;
@@ -255,7 +258,12 @@ export default class Migrate extends Vue {
 
     .topic-copy + .topic-visual {
         margin-right: 0;
-        margin-left: 3rem;
+        margin-left: 2rem; /* Less than the right margin, to fit in Firefox */
+    }
+
+    .topic-visual .account-ring {
+        width: 100%;
+        height: 100%;
     }
 
     .topic-visual.login-file {
@@ -263,6 +271,17 @@ export default class Migrate extends Vue {
         height: 11.75rem;
         margin-top: -2.875rem;
         margin-bottom: -2.875rem;
+    }
+
+    .topic-visual.login-file svg {
+        width: 100%;
+        height: 100%;
+    }
+
+    .topic-visual.qr-code {
+        font-size: 7.25rem;
+        padding: .375rem;
+        opacity: .4;
     }
 
     .link-read-article {

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,10 +769,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.3.0.tgz#654c05acccc193b7d79fb09b2faf2114945ff872"
   integrity sha512-je7fv+wP4nLEgTcZwu3FaGre22qkZ9AYGbStglVaJAxOH+3CvDnnOIa9IjGFaCEhtRQKRaQEvFqa5vN4IVnH+Q==
 
-"@nimiq/style@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.7.0.tgz#4443b99c062715c1c913fc3cf16eefd243d5de4a"
-  integrity sha512-oYnnbwI/jMN0nIvzKo8iKTmWbJXPL2WVbOl9o24OVb5gY+laz7cba6QVGdKQal+S2Hb1JKK99RV8z4Ve4fF4Yg==
+"@nimiq/style@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.7.1.tgz#e9f9423627fe55ea5b6078283312246010e45d77"
+  integrity sha512-tV6TTcJLk7GLXB22gYpieUUfOJxrQdymghOpmU5lDgkqv7f+D1RYSDAzo2gEhOZSsK3Kj8QdE9P6eNHGof29VQ==
 
 "@nimiq/style@^0.7.1":
   version "0.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,11 +774,6 @@
   resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.7.1.tgz#e9f9423627fe55ea5b6078283312246010e45d77"
   integrity sha512-tV6TTcJLk7GLXB22gYpieUUfOJxrQdymghOpmU5lDgkqv7f+D1RYSDAzo2gEhOZSsK3Kj8QdE9P6eNHGof29VQ==
 
-"@nimiq/style@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.7.1.tgz#e9f9423627fe55ea5b6078283312246010e45d77"
-  integrity sha512-tV6TTcJLk7GLXB22gYpieUUfOJxrQdymghOpmU5lDgkqv7f+D1RYSDAzo2gEhOZSsK3Kj8QdE9P6eNHGof29VQ==
-
 "@nimiq/utils@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.3.2.tgz#7728d417c6bafacfd2d617a8037839d2bc93a03a"


### PR DESCRIPTION
Resolves #233.

When during AM startup it is detected, that no accounts are stored, but the Keyguard has legacy accounts, then the current request is stored as `originalRouteName` and the user is redirected to the migration screen. When returning from an Keyguard-Export request, the user is again redirected to migration.

Only when migration succeeds and accounts are stored in the AM, then everything is back to normal and the orignal request is triggered (if it was not `migrate()` in the first place).

![image](https://user-images.githubusercontent.com/1828163/57798919-2f865d00-774e-11e9-997e-9e9dd51afb33.png)
![image](https://user-images.githubusercontent.com/1828163/57798955-488f0e00-774e-11e9-8441-e55311c26097.png)
