### PR TITLE
Mobile styles

### DIFF
--- a/public/blocking.css
+++ b/public/blocking.css
@@ -139,6 +139,24 @@ body {
     }
 }
 
+/* Mobile Layout */
+
+@media (max-width: 450px) {
+    html {
+        font-size: 7px;
+    }
+
+    #app {
+        width: 100%;
+        padding: 0;
+        justify-content: space-between;
+    }
+
+    #app > header {
+        padding: 2rem;
+    }
+}
+
 /*
  * Style copied from https://fonts.googleapis.com/css?family=Muli:400,600,700
  * But manually added woff fallback files.

--- a/src/App.vue
+++ b/src/App.vue
@@ -38,12 +38,6 @@ export default class App extends Vue {
 </script>
 
 <style>
-    @media (max-width: 450px) {
-        html {
-            --nimiq-size: 7px; /* For @nimiq/vue-components */
-        }
-    }
-
     #app > .container {
         display: flex;
         flex-direction: column;
@@ -95,5 +89,27 @@ export default class App extends Vue {
     .transition-fade-enter,
     .transition-fade-leave-to {
         opacity: 0;
+    }
+
+    /* Mobile Layout */
+
+    @media (max-width: 450px) {
+        #app > .container {
+            margin-bottom: 0 !important;
+            justify-content: flex-end;
+        }
+
+        .global-close {
+            position: absolute;
+            right: 1rem;
+            top: 2.5rem;
+            margin: 0;
+        }
+
+        .nq-card {
+            margin: 0;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+        }
     }
 </style>


### PR DESCRIPTION
Add layout for mobile screens, where the page is sticking to the bottom of the screen and there are no margins left and right. The global close button is at the top right next to the Nimiq logo.

Same problems with `html, body` overflow and scrollbars as in https://github.com/nimiq/keyguard-next/pull/342.