### PR TITLE
Show loader while router loads route

### DIFF
--- a/public/blocking.css
+++ b/public/blocking.css
@@ -39,21 +39,6 @@ body {
     padding-bottom: 9.5rem; /* height of header */
 }
 
-.loading-animation {
-    height: 10rem;
-    width: 10rem;
-}
-
-.loading-animation + h2 {
-    margin-top: 4rem;
-    padding-bottom: 8rem;
-    text-transform: uppercase;
-    font-size: 1.75rem;
-    font-weight: 600;
-    line-height: 0.86;
-    letter-spacing: 0.143em;
-}
-
 #app > header {
     box-sizing: content-box;
     width: calc(100% - 2 * 2rem); /* minus padding */

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
             <span class="logo-wordmark">Nimiq</span>
             <span class="logo-subtitle"></span>
         </header>
-        <div v-if="!isLoaded" class="loading">
+        <div v-if="!isLoaded || $root.loading" class="loading">
             <LoadingSpinner/>
         </div>
         <router-view v-else/>

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,18 +40,20 @@ if (window.location.origin === 'https://hub.nimiq-testnet.com') {
 }
 
 const app = new Vue({
-  data: { loading: false },
+  data: { loading: true },
   router,
   store,
   render: (h) => h(App),
 }).$mount('#app');
 
+let _loadingTimeout: number = 0;
 router.beforeEach((to, from, next) => {
-  app.loading = true;
+   // Only show loader when lazy-loading takes longer than 500ms
+  _loadingTimeout = window.setTimeout(() => app.loading = true, 500);
   next();
 });
-
 router.afterEach(() => {
+  window.clearTimeout(_loadingTimeout);
   app.loading = false;
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,11 +39,21 @@ if (window.location.origin === 'https://hub.nimiq-testnet.com') {
   });
 }
 
-new Vue({
+const app = new Vue({
+  data: { loading: false },
   router,
   store,
   render: (h) => h(App),
 }).$mount('#app');
+
+router.beforeEach((to, from, next) => {
+  app.loading = true;
+  next();
+});
+
+router.afterEach(() => {
+  app.loading = false;
+});
 
 // Types
 declare module 'vue/types/vue' {


### PR DESCRIPTION
Following advice on https://stackoverflow.com/a/44887358/4204380 and the docs on https://router.vuejs.org/guide/advanced/navigation-guards.html#navigation-guards, this makes the loading spinner display while the router is (lazy-)loading a route.

This prevents the loading spinner from disappearing as soon as the request/result is known but before the route's component is shown (because the component loading is only started after the request/result is set) and thus presents a "gap in loading".