### PR TITLE
Fix router loading state for quick subsequent navigation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,32 +34,35 @@ const rpcApi = new RpcApi(store, staticStore, router);
 Vue.prototype.$rpc = rpcApi; // rpcApi is started in App.vue->created()
 
 if (window.location.origin === 'https://hub.nimiq-testnet.com') {
-  Vue.use(VueRaven, {
-    dsn: 'https://92f2289fc2ac4c809dfa685911f865c2@sentry.io/1330855',
-  });
+    Vue.use(VueRaven, {
+        dsn: 'https://92f2289fc2ac4c809dfa685911f865c2@sentry.io/1330855',
+    });
 }
 
 const app = new Vue({
-  data: { loading: true },
-  router,
-  store,
-  render: (h) => h(App),
+    data: { loading: true },
+    router,
+    store,
+    render: (h) => h(App),
 }).$mount('#app');
 
-let _loadingTimeout: number = 0;
+let _loadingTimeout: number = -1;
 router.beforeEach((to, from, next) => {
-   // Only show loader when lazy-loading takes longer than 500ms
-  _loadingTimeout = window.setTimeout(() => app.loading = true, 500);
-  next();
+    if (_loadingTimeout === -1) {
+        // Only show loader when lazy-loading takes longer than 500ms
+        _loadingTimeout = window.setTimeout(() => app.loading = true, 500);
+    }
+    next();
 });
 router.afterEach(() => {
-  window.clearTimeout(_loadingTimeout);
-  app.loading = false;
+    window.clearTimeout(_loadingTimeout);
+    _loadingTimeout = -1;
+    app.loading = false;
 });
 
 // Types
 declare module 'vue/types/vue' {
-  interface Vue {
-    $rpc: RpcApi;
-  }
+    interface Vue {
+        $rpc: RpcApi;
+    }
 }


### PR DESCRIPTION
Relevant for example when the choose address flow forwards to the onboarding when no accounts are available.