### PR TITLE
Wallet id salting

### DIFF
--- a/src/lib/LedgerApi.ts
+++ b/src/lib/LedgerApi.ts
@@ -482,7 +482,8 @@ class LedgerApi {
                 await api.getPublicKey(LedgerApi.getBip32PathForKeyId(0), /*validate*/ false, /*display*/ false);
             const version = (await api.getAppConfiguration()).version;
             if (!LedgerApi._isAppVersionSupported(version)) throw new Error('Ledger Nimiq App is outdated.');
-            LedgerApi._currentlyConnectedWalletId = Nimiq.Hash.blake2b(firstAccountPubKeyBytes).toBase64();
+            // Use sha256 as blake2b yields the nimiq address
+            LedgerApi._currentlyConnectedWalletId = Nimiq.Hash.sha256(firstAccountPubKeyBytes).toBase64();
             if (walletId !== undefined && LedgerApi._currentlyConnectedWalletId !== walletId) {
                 throw new Error('Wrong Ledger connected');
             }

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -257,7 +257,7 @@ export default class WalletInfoCollector {
     }
 
     private static async _getWalletInfoInstance(walletType: WalletType, keyId: string): Promise<WalletInfo> {
-        const walletId = await WalletStore.deriveId(keyId);
+        const walletId = await WalletStore.Instance.deriveId(keyId);
 
         const existingWalletInfo = await WalletStore.Instance.get(walletId);
         if (existingWalletInfo) {

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -243,7 +243,7 @@ export default class Migrate extends Vue {
             const contracts = genesisVestingContracts.filter((contract) => contract.owner.equals(accountInfo.address));
 
             const walletInfo = new WalletInfo(
-                await WalletStore.deriveId(keyInfo.id),
+                await WalletStore.Instance.deriveId(keyInfo.id),
                 keyInfo.id,
                 ACCOUNT_DEFAULT_LABEL_LEGACY,
                 accounts,

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -46,7 +46,7 @@ export default class SignupSuccess extends Vue {
         );
 
         const walletInfo = new WalletInfo(
-            await WalletStore.deriveId(this.keyguardResult[0].keyId),
+            await WalletStore.Instance.deriveId(this.keyguardResult[0].keyId),
             this.keyguardResult[0].keyId,
             walletLabel,
             new Map<string, AccountInfo>().set(userFriendlyAddress, accountInfo),

--- a/tests/unit/WalletStore.spec.ts
+++ b/tests/unit/WalletStore.spec.ts
@@ -10,7 +10,7 @@ const indexedDB: IDBFactory = require('fake-indexeddb'); // tslint:disable-line:
 
 const DUMMY_ADDRESS = Nimiq.Address.fromUserFriendlyAddress('NQ07 0000 0000 0000 0000 0000 0000 0000 0000');
 const DUMMY: WalletInfo[] = [ // IDs must be alphabetically ordered, as the WalletStore uses the id as the primary index
-    new WalletInfo('0fe6067b138f', 'D+YGexOP0yDjr3Uf6WwO9a2/WjhNbZFLrRwdLfuvz9c=', 'Old',
+    new WalletInfo('1ae56b44c65d', 'D+YGexOP0yDjr3Uf6WwO9a2/WjhNbZFLrRwdLfuvz9c=', 'Old',
         new Map<string, AccountInfo>([
             ['NQ07 0000 0000 0000 0000 0000 0000 0000 0000', new AccountInfo('m/0\'', 'OldAddress', DUMMY_ADDRESS)],
         ]), [new VestingContractInfo(
@@ -19,11 +19,11 @@ const DUMMY: WalletInfo[] = [ // IDs must be alphabetically ordered, as the Wall
             Nimiq.Address.fromUserFriendlyAddress('NQ07 0000 0000 0000 0000 0000 0000 0000 0000'),
             0, 1500000, 120000, 3000000,
         )], WalletType.LEGACY),
-    new WalletInfo('2978bf29b377', 'KXi/KbN35+oYAIV2ummFjLWxfY/47fo/35Hfa3WNVA0=', 'Main',
+    new WalletInfo('57e1380cd0e2', 'KXi/KbN35+oYAIV2ummFjLWxfY/47fo/35Hfa3WNVA0=', 'Main',
         new Map<string, AccountInfo>([
             ['NQ07 0000 0000 0000 0000 0000 0000 0000 0000', new AccountInfo('m/0\'', 'MyAccount', DUMMY_ADDRESS)],
         ]), [], WalletType.BIP39),
-    new WalletInfo('2ec615522906', 'LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=', 'Ledger',
+    new WalletInfo('7a8616a79027', 'LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=', 'Ledger',
         new Map<string, AccountInfo>([
             ['NQ07 0000 0000 0000 0000 0000 0000 0000 0000', new AccountInfo('m/0\'', 'MyLedger', DUMMY_ADDRESS)],
         ]), [new HashedTimeLockedContractInfo(
@@ -35,10 +35,13 @@ const DUMMY: WalletInfo[] = [ // IDs must be alphabetically ordered, as the Wall
             1, 120, 3000e5,
         )], WalletType.LEDGER),
 ];
+const DUMMY_SALT = new Uint8Array(WalletStore.SALT_LENGTH);
 
 const beforeEachCallback = async () => {
     WalletStore.INDEXEDDB_IMPLEMENTATION = indexedDB;
     await Promise.all(DUMMY.map((wallet) => WalletStore.Instance.put(wallet)));
+    // @ts-ignore private method call
+    await WalletStore.Instance._putMetaData('salt', DUMMY_SALT);
     await WalletStore.Instance.close();
 };
 
@@ -132,22 +135,17 @@ describe('WalletStore', () => {
             {
                 // New keyId
                 keyId: 'pYMqO5SJxFRrb6EKBOf1vH7vcbqzcIyCZ2U3L//fWPo=',
-                accountId: 'a5832a3b9489',
+                accountId: '655884d15860',
             },
             {
                 // Existing keyId
                 keyId: 'KXi/KbN35+oYAIV2ummFjLWxfY/47fo/35Hfa3WNVA0=',
-                accountId: '2978bf29b377',
-            },
-            {
-                // Similar keyId (only last byte is different than existing above)
-                keyId: 'KXi/KbN35+oYAIV2ummFjLWxfY/47fo/35Hfa3WNVA1=',
-                accountId: '78bf29b377e7',
+                accountId: '57e1380cd0e2',
             },
         ];
 
         for (const vector of vectors) {
-            const id = await WalletStore.deriveId(vector.keyId);
+            const id = await WalletStore.Instance.deriveId(vector.keyId);
             expect(id).toBe(vector.accountId);
         }
     });

--- a/tests/unit/_setup.ts
+++ b/tests/unit/_setup.ts
@@ -3,4 +3,9 @@ const Nimiq = require('@nimiq/core'); // tslint:disable-line:no-var-requires var
 export const setup = () => {
     // @ts-ignore
     global.Nimiq = Nimiq;
+
+    // Mock WasmHelper as node clients don't provide the WasmHelper
+    Nimiq.WasmHelper = {
+        doImport: () => {}, // tslint:disable-line:no-empty
+    };
 };


### PR DESCRIPTION
Hashing with a random salt that does not leave the hub to avoid that an
external app can derive wallet id's from public keys (Legacy and Ledger
accounts) or get a hint for private key guessing / brute forcing (for BIP39)
as hashing the private key is cheaper than deriving the public key.