### PR TITLE
Preserve a disableBack flag through the parser.

### DIFF
--- a/client/HubApi.ts
+++ b/client/HubApi.ts
@@ -10,6 +10,7 @@ import { RequestType } from '../src/lib/RequestTypes';
 import {
     BasicRequest,
     SimpleRequest,
+    OnboardRequest,
     CheckoutRequest,
     SignTransactionRequest,
     RenameRequest,
@@ -117,7 +118,7 @@ export default class HubApi<DB extends BehaviorType = BehaviorType.POPUP> { // D
      */
 
     public onboard<B extends BehaviorType = DB>(
-        request: BasicRequest,
+        request: OnboardRequest,
         requestBehavior: RequestBehavior<B> = this._defaultBehavior as any,
     ): Promise<B extends BehaviorType.REDIRECT ? void : Account[]> {
         return this._request(requestBehavior, RequestType.ONBOARD, [request]);

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -3,6 +3,7 @@ import { RequestType } from './RequestTypes';
 
 export interface BasicRequest {
     appName: string;
+    disableBack?: boolean;
 }
 
 export interface SimpleRequest extends BasicRequest {

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -3,7 +3,6 @@ import { RequestType } from './RequestTypes';
 
 export interface BasicRequest {
     appName: string;
-    disableBack?: boolean;
 }
 
 export interface SimpleRequest extends BasicRequest {
@@ -12,6 +11,10 @@ export interface SimpleRequest extends BasicRequest {
 
 export interface SimpleResult {
     success: true;
+}
+
+export interface OnboardRequest extends BasicRequest {
+    disableBack?: boolean;
 }
 
 export interface SignTransactionRequest extends BasicRequest {
@@ -130,6 +133,7 @@ export type RpcRequest = SignTransactionRequest
                        | CheckoutRequest
                        | BasicRequest
                        | SimpleRequest
+                       | OnboardRequest
                        | RenameRequest
                        | SignMessageRequest
                        | ExportRequest;

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -3,6 +3,7 @@ import { State } from '@nimiq/rpc';
 import {
     BasicRequest,
     SimpleRequest,
+    OnboardRequest,
     SignTransactionRequest,
     CheckoutRequest,
     SignMessageRequest,
@@ -14,6 +15,7 @@ import {
     RequestType,
     ParsedBasicRequest,
     ParsedSimpleRequest,
+    ParsedOnboardRequest,
     ParsedSignTransactionRequest,
     ParsedCheckoutRequest,
     ParsedSignMessageRequest,
@@ -84,6 +86,12 @@ export class RequestParser {
                     ),
                 } as ParsedCheckoutRequest;
             case RequestType.ONBOARD:
+                const onboardRequest = request as OnboardRequest;
+                return {
+                    kind: requestType,
+                    appName: onboardRequest.appName,
+                    disableBack: !!onboardRequest.disableBack,
+                } as ParsedOnboardRequest;
             case RequestType.SIGNUP:
             case RequestType.CHOOSE_ADDRESS:
             case RequestType.LOGIN:
@@ -91,7 +99,6 @@ export class RequestParser {
                 return {
                     kind: requestType,
                     appName: request.appName,
-                    disableBack: request.disableBack,
                 } as ParsedBasicRequest;
             case RequestType.CHANGE_PASSWORD:
             case RequestType.LOGOUT:
@@ -177,14 +184,18 @@ export class RequestParser {
                     flags: checkoutRequest.flags,
                     validityDuration: checkoutRequest.validityDuration,
                 } as CheckoutRequest;
-            case RequestType.MIGRATE:
             case RequestType.ONBOARD:
+                const onboardRequest = request as ParsedOnboardRequest;
+                return {
+                    appName: onboardRequest.appName,
+                    disableBack: onboardRequest.disableBack,
+                } as OnboardRequest;
             case RequestType.SIGNUP:
             case RequestType.CHOOSE_ADDRESS:
             case RequestType.LOGIN:
+            case RequestType.MIGRATE:
                 return {
                     appName: request.appName,
-                    disableBack: request.disableBack,
                 } as BasicRequest;
             case RequestType.CHANGE_PASSWORD:
             case RequestType.LOGOUT:

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -91,6 +91,7 @@ export class RequestParser {
                 return {
                     kind: requestType,
                     appName: request.appName,
+                    disableBack: request.disableBack,
                 } as ParsedBasicRequest;
             case RequestType.CHANGE_PASSWORD:
             case RequestType.LOGOUT:
@@ -183,6 +184,7 @@ export class RequestParser {
             case RequestType.LOGIN:
                 return {
                     appName: request.appName,
+                    disableBack: request.disableBack,
                 } as BasicRequest;
             case RequestType.CHANGE_PASSWORD:
             case RequestType.LOGOUT:

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -18,11 +18,14 @@ export enum RequestType {
 export interface ParsedBasicRequest {
     kind: RequestType;
     appName: string;
-    disableBack?: boolean;
 }
 
 export interface ParsedSimpleRequest extends ParsedBasicRequest {
     walletId: string;
+}
+
+export interface ParsedOnboardRequest extends ParsedBasicRequest {
+    disableBack: boolean;
 }
 
 export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
@@ -68,6 +71,7 @@ export type ParsedRpcRequest = ParsedSignTransactionRequest
                              | ParsedCheckoutRequest
                              | ParsedBasicRequest
                              | ParsedSimpleRequest
+                             | ParsedOnboardRequest
                              | ParsedRenameRequest
                              | ParsedSignMessageRequest
                              | ParsedExportRequest;

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -18,6 +18,7 @@ export enum RequestType {
 export interface ParsedBasicRequest {
     kind: RequestType;
     appName: string;
+    disableBack?: boolean;
 }
 
 export interface ParsedSimpleRequest extends ParsedBasicRequest {

--- a/src/views/OnboardingSelector.vue
+++ b/src/views/OnboardingSelector.vue
@@ -19,7 +19,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { BrowserDetection } from '@nimiq/utils';
 import OnboardingMenu from '../components/OnboardingMenu.vue';
-import { ParsedBasicRequest, RequestType } from '@/lib/RequestTypes';
+import { ParsedOnboardRequest, RequestType } from '@/lib/RequestTypes';
 import { Static } from '@/lib/StaticStore';
 import { DEFAULT_KEY_PATH, ERROR_CANCELED } from '@/lib/Constants';
 import CookieHelper from '../lib/CookieHelper';
@@ -28,7 +28,7 @@ import { ArrowLeftSmallIcon } from '@nimiq/vue-components';
 
 @Component({components: {OnboardingMenu, NotEnoughCookieSpace, ArrowLeftSmallIcon}})
 export default class OnboardingSelector extends Vue {
-    @Static private request!: ParsedBasicRequest;
+    @Static private request!: ParsedOnboardRequest;
     @Static private originalRouteName?: string;
 
     private notEnoughCookieSpace = false;


### PR DESCRIPTION
I am not sure if we should add the flag to the `BasicRequest`, as that would mean it would be available for every request, which it isn't. It's only respected in the onboarding menu.