### PR TITLE
Fix ErrorHandler for changed request types

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -117,6 +117,9 @@ const store: StoreOptions<RootState> = {
                 return contract.address.toUserFriendlyAddress() === address;
             }));
         },
+        findWalletByKeyId: (state) => (keyId: string): WalletInfo | undefined => {
+            return state.wallets.find((wallet) => wallet.keyId === keyId);
+        },
         activeWallet: (state, getters): WalletInfo | undefined => {
             if (!state.activeWalletId) return undefined;
             return getters.findWallet(state.activeWalletId);

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -37,12 +37,10 @@ export default class ErrorHandler extends Vue {
             }
 
             const walletInfo = await WalletStore.Instance.get(walletId);
-            if (!walletInfo) {
-                this.$rpc.reject(this.keyguardResult); // return it to caller
-                return;
+            if (walletInfo) {
+                walletInfo.keyMissing = true;
+                await WalletStore.Instance.put(walletInfo);
             }
-            walletInfo.keyMissing = true;
-            await WalletStore.Instance.put(walletInfo);
 
             // Redirect to login
             staticStore.originalRouteName = this.request.kind;

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -2,13 +2,20 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { State } from 'vuex-class';
+import { State, Getter } from 'vuex-class';
 import staticStore, { Static } from '../lib/StaticStore';
-import { ParsedRpcRequest, ParsedSimpleRequest, RequestType } from '../lib/RequestTypes';
+import {
+    RequestType,
+    ParsedRpcRequest,
+    ParsedSimpleRequest,
+    ParsedSignMessageRequest,
+    ParsedSignTransactionRequest,
+} from '../lib/RequestTypes';
 import { Errors } from '@nimiq/keyguard-client';
 import { WalletStore } from '../lib/WalletStore';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { DEFAULT_KEY_PATH } from '../lib/Constants';
+import { WalletInfo } from '../lib/WalletInfo';
 
 @Component
 export default class ErrorHandler extends Vue {
@@ -16,30 +23,22 @@ export default class ErrorHandler extends Vue {
     @Static protected keyguardRequest?: KeyguardClient.Request;
     @State protected keyguardResult!: Error;
 
+    @Getter private findWalletByAddress!: (address: string, includeContracts: boolean) => WalletInfo | undefined;
+    @Getter private findWalletByKeyId!: (keyId: string) => WalletInfo | undefined;
+
     public async created() {
         if (!(this.keyguardResult instanceof Error)) return;
 
         if (this.keyguardResult.message === Errors.Messages.KEY_NOT_FOUND) {
-            let walletId: string;
-            if ((this.request as ParsedSimpleRequest).walletId) {
-                // The walletId is already in the Accounts request
-                walletId = (this.request as ParsedSimpleRequest).walletId;
-            } else if (this.request.kind === RequestType.CHECKOUT
-                    || this.request.kind === RequestType.SIGN_MESSAGE) {
-                // Accounts request was Checkout/SignMessage.
-                // The walletId (keyId in the Keyguard environment) is in the keyguardRequest after picking the account
-                walletId = (this.keyguardRequest as KeyguardClient.SignTransactionRequest).keyId;
-            } else {
-                // This really should not happen.
-                // Executing this code would mean i.e. a CreateRequest fired KEY_NOT_FOUND which it does not throw
-                this.$rpc.reject(this.keyguardResult);
+            try {
+                const walletInfo = await this.getWalletForThisRequest();
+                if (walletInfo) {
+                    walletInfo.keyMissing = true;
+                    await WalletStore.Instance.put(walletInfo);
+                }
+            } catch (error) {
+                this.$rpc.reject(error);
                 return;
-            }
-
-            const walletInfo = await WalletStore.Instance.get(walletId);
-            if (walletInfo) {
-                walletInfo.keyMissing = true;
-                await WalletStore.Instance.put(walletInfo);
             }
 
             // Redirect to login
@@ -65,6 +64,30 @@ export default class ErrorHandler extends Vue {
         // TODO more Error Handling
 
         this.$rpc.reject(this.keyguardResult);
+    }
+
+    private async getWalletForThisRequest(): Promise<WalletInfo | undefined> {
+        if ((this.request as ParsedSimpleRequest).walletId) {
+            // The walletId is already in the Hub request
+            return WalletStore.Instance.get((this.request as ParsedSimpleRequest).walletId);
+        } else if ((this.request as ParsedSignTransactionRequest).sender
+                || (this.request as ParsedSignMessageRequest).signer) {
+            // Hub request was SignTransaction/Checkout/SignMessage.
+            // The wallet can be found by the (optional) sender/signer address in the Hub request
+            const address = (this.request as ParsedSignTransactionRequest).sender
+                            || (this.request as ParsedSignMessageRequest).signer;
+            return this.findWalletByAddress(address.toUserFriendlyAddress(), true);
+        } else if (this.request.kind === RequestType.CHECKOUT
+                || this.request.kind === RequestType.SIGN_MESSAGE) {
+            // The keyId of the selected address is in the keyguardRequest
+            return this.findWalletByKeyId((this.keyguardRequest as KeyguardClient.SignMessageRequest).keyId);
+        } else {
+            // This really should not happen.
+            // Executing this code would mean i.e. a CreateRequest fired KEY_NOT_FOUND which it does not throw
+            const err = new Error(`Unexpected: ${this.request.kind} request threw a KEY_NOT_FOUND error.`);
+            err.stack = this.keyguardResult.stack;
+            throw err;
+        }
     }
 }
 </script>

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -66,7 +66,7 @@ export default class ErrorHandler extends Vue {
         this.$rpc.reject(this.keyguardResult);
     }
 
-    private async getWalletForThisRequest(): Promise<WalletInfo | undefined> {
+    private async getWalletForThisRequest(): Promise<WalletInfo | undefined | null> {
         if ((this.request as ParsedSimpleRequest).walletId) {
             // The walletId is already in the Hub request
             return WalletStore.Instance.get((this.request as ParsedSimpleRequest).walletId);


### PR DESCRIPTION
The `ErrorHandler` still expected e.g. the `sign-transaction` request to contain the `walletId` in the request, which it doesn't do anymore (sign-transaction only uses the `sender` prop). So these changes now fix the handler to use the existing props.

It also now redirects to Keyguard login (import) even when Hub wallet data is not found. (This last part is optional and can be removed from this PR, if we don't want to do this (with these changes the ErrorHandler should again handle all KEY_NOT_FOUND errors correctly and hub-meta-data should always exist (if it doesn't, the RpcApi should reject the request already at the beginning)).