### PR TITLE
Show error page instead of redirect in case of missing request

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ The following values can be changed via configuration files:
 - networkEndpoint: The location of the network iframe instance you want to use.
 - privilegedOrigins: An array of origins with special access rights, nameley
   permission to use iframe methods like `list()`.
-- redirectTarget: In case of empty referrer or absence of request, the user is
-  redirected to this page.
 
 The default config file is `config.local.ts`. To use a different file
 (especially useful for deployment), set an environment variable

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -5,6 +5,5 @@ export default {
     network: NETWORK_TEST,
     networkEndpoint: 'https://network.nimiq-testnet.com',
     privilegedOrigins: [ '*' ],
-    redirectTarget: window.location.protocol + '//' + window.location.hostname + ':8080/demos.html',
     reportToSentry: false,
 };

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -5,6 +5,5 @@ export default {
     network: NETWORK_MAIN,
     networkEndpoint: 'https://network.nimiq.com',
     privilegedOrigins: [ 'https://safe.nimiq.com' ],
-    redirectTarget: 'https://safe.nimiq.com',
     reportToSentry: true,
 };

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -8,6 +8,5 @@ export default {
         'https://safe.nimiq-testnet.com',
         'https://hub.nimiq-testnet.com', // For testing with the deployed demos.html page
     ],
-    redirectTarget: 'https://safe.nimiq-testnet.com',
     reportToSentry: true,
 };

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -74,14 +74,9 @@ export default class RpcApi {
         this._keyguardClient.init().catch(console.error); // TODO: Provide better error handling here
         if (this._store.state.keyguardResult) return;
 
-        // If there is no request redirect to Safe (default) in redirect case,
-        // or show error in popup case.
+        // If there is no valid request, show an error page
         const onClientTimeout = () => {
-            if (window.opener === null) {
-                location.href = Config.redirectTarget;
-            } else {
-                this._router.replace(`/${REQUEST_ERROR}`);
-            }
+            this._router.replace(`/${REQUEST_ERROR}`);
         };
         this._server.init(onClientTimeout);
     }

--- a/src/views/RequestError.vue
+++ b/src/views/RequestError.vue
@@ -1,11 +1,11 @@
 <template>
-    <div class="container">
+    <div class="container pad-bottom">
         <SmallPage>
             <StatusScreen
                 state="error"
                 title="Invalid request"
                 message="Something went wrong with your request. Please try again."
-                mainAction="Close"
+                :mainAction="_mainAction"
                 @main-action="_close"
             />
         </SmallPage>
@@ -20,7 +20,15 @@ import StatusScreen from '../components/StatusScreen.vue';
 @Component({components: {StatusScreen, SmallPage}})
 export default class RequestError extends Vue {
     private _close() {
-        window.close();
+        if (window.history.length > 1) {
+            window.history.back();
+        } else {
+            window.close();
+        }
+    }
+
+    private get _mainAction(): string {
+        return window.history.length > 1 ? 'Go back' : 'Close';
     }
 }
 </script>


### PR DESCRIPTION
This fixes the issue of a redirect happening in a popup, when the popup is initially blocked by a popup-blocker but then opened anyway from the browser prompt. In those cases, the reference to the popup is lost in the opening window and the popup receives no postMessage request within the timeout. Additionally, because the reference from the opening window got lost, the `window.opener` in the popup is now `null`, triggering the redirect case, opening the Safe in the popup.

I believe we don't need a redirect-on-error and can just display the error page. The error page then detects if the user can go back to the sending page, or close the window otherwise.