### PR TITLE
Fix initialization of Network client

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@nimiq/iqons": "^1.5.0",
         "@nimiq/keyguard-client": "^1.0.0",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
-        "@nimiq/network-client": "^0.2.1",
+        "@nimiq/network-client": "^0.2.3",
         "@nimiq/rpc": "^0.3.0",
         "@nimiq/style": "^0.7.2",
         "@nimiq/utils": "^0.3.2",

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -17,8 +17,6 @@ import { VestingContractInfo } from '../lib/ContractInfo';
 @Component
 class Network extends Vue {
     private static _hasOrSyncsOnTopOfConsensus = false;
-    private _clientInitiatedPromise!: Promise<void>;
-    private _clientInitiatedResolver!: () => void;
 
     private boundListeners: Array<[NetworkClient.Events, (...args: any[]) => void]> = [];
 
@@ -193,8 +191,6 @@ class Network extends Vue {
     }
 
     private created() {
-        this._clientInitiatedPromise = new Promise((res) => this._clientInitiatedResolver = res);
-
         this.$on(Network.Events.CONSENSUS_ESTABLISHED, () => {
             Network._hasOrSyncsOnTopOfConsensus = true;
         });
@@ -212,12 +208,10 @@ class Network extends Vue {
 
     private async _getNetworkClient(): Promise<NetworkClient> {
         if (!NetworkClient.hasInstance()) {
-            const networkClient = NetworkClient.createInstance(Config.networkEndpoint);
-            await networkClient.init();
-            this._clientInitiatedResolver();
+            NetworkClient.createInstance(Config.networkEndpoint);
         }
-
-        await this._clientInitiatedPromise;
+        // Make sure the client is initialized
+        await NetworkClient.Instance.init();
 
         if (this.boundListeners.length === 0) {
             this._registerNetworkListener(NetworkClient.Events.API_READY,

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,10 +744,10 @@
   version "0.0.0"
   resolved "https://github.com/nimiq/ledger-api.git#a7d86a47b46d21ec2afea94086b2942ea1adb575"
 
-"@nimiq/network-client@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.2.1.tgz#125bfbf83a27c321d5226dae1d07aa6fae01e7ed"
-  integrity sha512-IdmeYibnnY7DQkfVZfGgY2aQ8v4pJ2jllYJqDi/xeTPnR3loKqvJsy4NoPMPNMgaFpy0aU2oVJq0OzlW5Vl/IA==
+"@nimiq/network-client@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.2.3.tgz#8936a971189b761c45b4ab29e8093792e472798b"
+  integrity sha512-Pb5Di3IDHKAkYEGCkO2BT8Wvc6JxhioZnQjj4JdwYFi9sv4NcdxF7wlKPKuJ1Z+Zn4xl5edM4AnHF9Kd/zjLAA==
   dependencies:
     "@nimiq/core-web" "1.4.3"
     "@nimiq/rpc-events" "^0.0.8"


### PR DESCRIPTION
Requires https://github.com/nimiq/network/pull/11 to be published first.

Fixes a bug introduced in https://github.com/nimiq/hub/pull/312 that results in calls to instances of the Network component to never execute for instances that are not the first created. This bug occurred as the promise waiting for the client initialization was not shared across Network component instances.

This fix has specifically an implication on Checkouts with Ledger where multiple views with a Network component are involved.