### PR TITLE
WalletInfoCollector,SignupLedger: cancel Ledger account derivation on error

### DIFF
--- a/src/lib/LedgerApi.ts
+++ b/src/lib/LedgerApi.ts
@@ -580,7 +580,7 @@ class LedgerApi {
         const listenersForEvent = LedgerApi._listeners.get(eventName);
         if (!listenersForEvent) return;
         for (const listener of listenersForEvent) {
-            listener(...args);
+            setTimeout(listener, 0, ...args);
         }
     }
 

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -122,6 +122,10 @@ export default class SignupLedger extends Vue {
             } catch (e) {
                 this.failedFetchingAccounts = true;
                 if (tryCount >= 5) throw e;
+                console.warn('Error while collecting Ledger WalletInfo, retrying', e);
+                if (!LedgerApi.isBusy) continue;
+                // await Ledger request from current iteration to be cancelled to able to start the next one
+                await new Promise((resolve) => LedgerApi.once(LedgerApi.EventType.REQUEST_CANCELLED, resolve));
             }
         }
 


### PR DESCRIPTION
This avoids unnecessary calls to the Ledger and fixes Sentry error HUB-43 (Only one
call to Ledger at a time allowed) which occurred when the wallet info collection
errored (for example due to a failed network request) and SignupLedger immediately
retried to launch the wallet collection.

It's recommendable to ignore whitespace changes for easier reviewability.