### PR TITLE
Add new accounts to Vuex when they are created, not when they are needed

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -105,6 +105,13 @@ const store: StoreOptions<RootState> = {
                 });
             });
         },
+        addWalletAndSetActive({ commit }, walletInfo: WalletInfo) {
+            commit('addWallet', walletInfo);
+            commit('setActiveAccount', {
+                walletId: walletInfo.id,
+                userFriendlyAddress: walletInfo.accounts.values().next().value.userFriendlyAddress,
+            });
+        },
     },
     getters: {
         findWallet: (state) => (id: string): WalletInfo | undefined => {

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -48,8 +48,6 @@ export default class ChooseAddress extends Vue {
     }) => any;
 
     public async created() {
-        await this.handleOnboardingResult();
-
         if (this.processedWallets.length === 0) {
             this.goToOnboarding(true);
         }
@@ -85,31 +83,6 @@ export default class ChooseAddress extends Vue {
             this.$rpc.routerReplace(RequestType.ONBOARD);
         }
         this.$rpc.routerPush(RequestType.ONBOARD);
-    }
-
-    private async handleOnboardingResult() {
-        // Check if we are returning from an onboarding request
-        if (staticStore.sideResult && !(staticStore.sideResult instanceof Error)) {
-            const sideResult = staticStore.sideResult as Account[];
-
-            // Add imported wallets to Vuex store
-            for (const account of sideResult) {
-                const walletInfo = await WalletStore.Instance.get(account.accountId);
-                if (walletInfo) {
-                    this.$addWallet(walletInfo);
-
-                    // Set as activeWallet and activeAccount
-                    // FIXME: Also handle active account we get from store
-                    const activeAccount = walletInfo.accounts.values().next().value;
-
-                    this.$setActiveAccount({
-                        walletId: walletInfo.id,
-                        userFriendlyAddress: activeAccount.userFriendlyAddress,
-                    });
-                }
-            }
-        }
-        delete staticStore.sideResult;
     }
 
     private close() {

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -41,7 +41,6 @@ export default class ChooseAddress extends Vue {
     @Getter private findWallet!: (id: string) => WalletInfo | undefined;
     @Getter private processedWallets!: WalletInfo[];
 
-    @Mutation('addWallet') private $addWallet!: (walletInfo: WalletInfo) => any;
     @Mutation('setActiveAccount') private $setActiveAccount!: (payload: {
         walletId: string,
         userFriendlyAddress: string,

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { State } from 'vuex-class';
+import { State, Action } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { BrowserDetection } from '@nimiq/utils';
 import { SmallPage } from '@nimiq/vue-components';
@@ -34,6 +34,8 @@ import { ERROR_COOKIE_SPACE } from '../lib/Constants';
 export default class LoginSuccess extends Vue {
     @Static private request!: ParsedBasicRequest;
     @State private keyguardResult!: KeyguardClient.KeyResult;
+
+    @Action('addWalletAndSetActive') private $addWalletAndSetActive!: (walletInfo: WalletInfo) => any;
 
     private walletInfos: WalletInfo[] = [];
     private state: StatusScreen.State = StatusScreen.State.LOADING;
@@ -152,6 +154,11 @@ export default class LoginSuccess extends Vue {
 
     private async done() {
         if (!this.walletInfos.length) throw new Error('WalletInfo not ready.');
+
+        // Add wallets to vuex
+        for (const walletInfo of this.walletInfos) {
+            this.$addWalletAndSetActive(walletInfo);
+        }
 
         const result = this.walletInfos.map((walletInfo) => ({
                 accountId: walletInfo.id,

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -59,8 +59,6 @@ export default class SignMessage extends Vue {
     private showAccountSelector = false;
 
     private async created() {
-        await this.handleOnboardingResult();
-
         if (this.request.signer) {
             const wallet = this.findWalletByAddress(this.request.signer.toUserFriendlyAddress(), false);
             if (wallet && wallet.type !== WalletType.LEDGER) {
@@ -128,30 +126,6 @@ export default class SignMessage extends Vue {
         } else {
             this.$rpc.routerPush(RequestType.ONBOARD);
         }
-    }
-
-    private async handleOnboardingResult() {
-        // Check if we are returning from an onboarding request
-        if (staticStore.sideResult && !(staticStore.sideResult instanceof Error)) {
-            const sideResult = staticStore.sideResult as Account[];
-
-            // Add imported wallets to Vuex store
-            for (const account of sideResult) {
-                const walletInfo = await WalletStore.Instance.get(account.accountId);
-                if (walletInfo) {
-                    this.$addWallet(walletInfo);
-
-                    // FIXME: Also handle active account we get from store
-                    const activeAccount = walletInfo.accounts.values().next().value;
-
-                    this.$setActiveAccount({
-                        walletId: walletInfo.id,
-                        userFriendlyAddress: activeAccount.userFriendlyAddress,
-                    });
-                }
-            }
-        }
-        delete staticStore.sideResult;
     }
 
     private close() {

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -50,7 +50,6 @@ export default class SignMessage extends Vue {
     @Getter private findWallet!: (id: string) => WalletInfo | undefined;
     @Getter private findWalletByAddress!: (address: string, includeContracts: boolean) => WalletInfo | undefined;
 
-    @Mutation('addWallet') private $addWallet!: (walletInfo: WalletInfo) => any;
     @Mutation('setActiveAccount') private $setActiveAccount!: (payload: {
         walletId: string,
         userFriendlyAddress: string,

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -53,6 +53,7 @@ import { AccountInfo } from '../lib/AccountInfo';
 import { WalletStore } from '../lib/WalletStore';
 import { ERROR_CANCELED } from '../lib/Constants';
 import LabelingMachine from '@/lib/LabelingMachine';
+import { Action } from 'vuex-class';
 
 @Component({components: {
     PageBody, SmallPage, PageHeader,
@@ -70,6 +71,8 @@ export default class SignupLedger extends Vue {
     };
 
     @Static private request!: ParsedBasicRequest;
+
+    @Action('addWalletAndSetActive') private $addWalletAndSetActive!: (walletInfo: WalletInfo) => any;
 
     private state: string = SignupLedger.State.LOADING;
     private walletInfo: WalletInfo | null = null;
@@ -173,6 +176,9 @@ export default class SignupLedger extends Vue {
     }
 
     private async done() {
+        // Add wallet to vuex
+        this.$addWalletAndSetActive(this.walletInfo!);
+
         this.state = SignupLedger.State.FINISHED;
         setTimeout(() => {
             const result: Account[] = [{

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -16,7 +16,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage, CheckmarkIcon } from '@nimiq/vue-components';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
-import { State } from 'vuex-class';
+import { State, Action } from 'vuex-class';
 import { WalletStore } from '@/lib/WalletStore';
 import { Account } from '../lib/PublicRequestTypes';
 import StatusScreen from '@/components/StatusScreen.vue';
@@ -26,6 +26,8 @@ import LabelingMachine from '@/lib/LabelingMachine';
 @Component({components: {SmallPage, StatusScreen, CheckmarkIcon}})
 export default class SignupSuccess extends Vue {
     @State private keyguardResult!: KeyguardClient.KeyResult;
+
+    @Action('addWalletAndSetActive') private $addWalletAndSetActive!: (walletInfo: WalletInfo) => any;
 
     private title: string = 'Storing your Account';
     private state: StatusScreen.State = StatusScreen.State.LOADING;
@@ -58,6 +60,9 @@ export default class SignupSuccess extends Vue {
         );
 
         await WalletStore.Instance.put(walletInfo);
+
+        // Add wallet to vuex
+        this.$addWalletAndSetActive(walletInfo);
 
         // Artificially delay, to display loading status
         await new Promise((res) => setTimeout(res, 2000));


### PR DESCRIPTION
To avoid having to actively check for and add newly added accounts from a side-request, the side-requests should add their created/logged-in accounts to the Vuex store automatically. This reduces code and headaches.