### PR TITLE
Warn about potentially incomplete addresses on ledger signup

### DIFF
--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -167,7 +167,7 @@ export default class LoginSuccess extends Vue {
         if (this.receiptsError) {
             this.title = 'Your Addresses may be\nincomplete.';
             this.state = StatusScreen.State.WARNING;
-            this.message = 'We might have missed used addresses that have no balance.';
+            this.message = 'Used addresses without balance might have been missed.';
             this.action = 'Continue';
             await new Promise((resolve) => { this.resolve = resolve; });
         }

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -119,7 +119,7 @@ export default class SignupLedger extends Vue {
 
     private get statusScreenMessage() {
         if (this.state !== SignupLedger.State.FETCHING_INCOMPLETE) return '';
-        else return 'We might have missed used addresses that have no balance.';
+        else return 'Used addresses without balance might have been missed.';
     }
 
     private get statusScreenAction() {


### PR DESCRIPTION
Warn user that addresses are potentially incomplete if transaction receipts could not be retrieved successfully.
This behavior is similar to the incomplete import of Keyguard accounts (https://github.com/nimiq/hub/pull/179).
However, the Ledger flow eventually ends in a success screen, even if there was a warning which I consider more consistent. (Edit: I just saw LoginSuccess had been changed to this behavior in a later commit too)