### PR TITLE
Remove success screen from SignTransactionSuccess

### DIFF
--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -1,28 +1,16 @@
 <template>
-    <div class="container pad-bottom">
-        <SmallPage>
-            <StatusScreen state="success">
-                <template slot="success">
-                    <CheckmarkIcon/>
-                    <h1 class="title nq-h1">Sending your<br>transaction now.</h1>
-                </template>
-            </StatusScreen>
-            <Network ref="network" :visible="false"/>
-        </SmallPage>
-    </div>
+    <Network ref="network" :visible="false"/>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import Network from '@/components/Network.vue';
-import { SmallPage, CheckmarkIcon } from '@nimiq/vue-components';
 import { SignedTransaction } from '../lib/PublicRequestTypes';
 import { State } from 'vuex-class';
 import { Static } from '../lib/StaticStore';
-import StatusScreen from '../components/StatusScreen.vue';
 import KeyguardClient from '@nimiq/keyguard-client';
 
-@Component({components: {Network, SmallPage, StatusScreen, CheckmarkIcon}})
+@Component({components: {Network}})
 export default class SignTransactionSuccess extends Vue {
     @Static private keyguardRequest!: KeyguardClient.SignTransactionRequest;
     @State private keyguardResult!: KeyguardClient.SignTransactionResult;
@@ -33,7 +21,7 @@ export default class SignTransactionSuccess extends Vue {
         }, this.keyguardResult, this.keyguardRequest));
         const result: SignedTransaction = await (this.$refs.network as Network).makeSignTransactionResult(tx);
 
-        setTimeout(() => this.$rpc.resolve(result), StatusScreen.SUCCESS_REDIRECT_DELAY);
+        this.$rpc.resolve(result);
     }
 }
 </script>


### PR DESCRIPTION
Based on feedback by the UX designers, a success screen before the actual success of an action is bad UX and should be avoided. Thus we remove the success screen from the SendTransaction flow, as the transaction is only sent by the Safe.