### PR TITLE
Adapt to nano-api with Core Client (1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@nimiq/iqons": "^1.5.0",
         "@nimiq/keyguard-client": "^1.0.0",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
-        "@nimiq/network-client": "^0.2.3",
+        "@nimiq/network-client": "^0.3.0",
         "@nimiq/rpc": "^0.3.0",
         "@nimiq/style": "^0.7.2",
         "@nimiq/utils": "^0.3.2",

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -20,27 +20,6 @@ class Network extends Vue {
 
     private boundListeners: Array<[NetworkClient.Events, (...args: any[]) => void]> = [];
 
-    public async connect() {
-        // Load network iframe (automatically starts a pico consensus which does not upgrade to nano)
-        const client = await this._getNetworkClient();
-    }
-
-    public async connectPico(addresses: string[], upgradeToNano = false): Promise<Map<string, number>> {
-        const client = await this._getNetworkClient();
-        // Rerun pico consensus to get balances
-        return client.connectPico(addresses, upgradeToNano);
-    }
-
-    public async connectNano() {
-        const client = await this._getNetworkClient();
-        return client.connectNano();
-    }
-
-    public async disconnect() {
-        if (!NetworkClient.hasInstance()) return;
-        return NetworkClient.Instance.disconnect();
-    }
-
     public async createTx({
         sender,
         senderType = Nimiq.Account.Type.BASIC,

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -173,7 +173,7 @@ export default class Checkout extends Vue {
 
         // Get balances through pico consensus, also triggers head-change event
         const network = (this.$refs.network as Network);
-        const balances: Map<string, number> = await network.connectPico(addresses);
+        const balances: Map<string, number> = await network.getBalances(addresses);
 
         // Update accounts/contracts with their balances
         // (The accounts are still references to themselves in the wallets' accounts maps)

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -180,7 +180,7 @@ export default class Migrate extends Vue {
     private async getBalances() {
         // Get balances from network
         const network = (this.$refs.network as Network);
-        const balances: Map<string, number> = await network.connectPico(
+        const balances: Map<string, number> = await network.getBalances(
             this.legacyAccounts.map((account) => account.userFriendlyAddress));
         console.log(balances);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,10 +744,10 @@
   version "0.0.0"
   resolved "https://github.com/nimiq/ledger-api.git#a7d86a47b46d21ec2afea94086b2942ea1adb575"
 
-"@nimiq/network-client@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.2.3.tgz#8936a971189b761c45b4ab29e8093792e472798b"
-  integrity sha512-Pb5Di3IDHKAkYEGCkO2BT8Wvc6JxhioZnQjj4JdwYFi9sv4NcdxF7wlKPKuJ1Z+Zn4xl5edM4AnHF9Kd/zjLAA==
+"@nimiq/network-client@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.3.0.tgz#0b5a37b2a0a1fb911d77aaab1836ce73d81d4dd3"
+  integrity sha512-sWTYjOD2sQ/+hgLo87n/z58N7ar+ggJz7qpbSv+J3VVeKZjHSF95FPJgrzWpj4i+rbjkG8VtsdjgDGGl/salJA==
   dependencies:
     "@nimiq/core-web" "1.4.3"
     "@nimiq/rpc-events" "^0.0.8"


### PR DESCRIPTION
This PR adds support for the new nano-api with Client API to the `master` branch.

The changes required in the cashlink code will follow after this PR or the cashlink PR has been merged, whichever is first.