### PR TITLE
IdenticonSelector: only focus on selection, not on dismissal.

### DIFF
--- a/src/components/IdenticonSelector.vue
+++ b/src/components/IdenticonSelector.vue
@@ -83,7 +83,7 @@
         private _selectAccount(account: AccountInfo | null) {
             this.selectedAccount = account;
             if (!account || this.confirmAccountSelection) {
-                if (isDesktop()) {
+                if (account && isDesktop()) {
                     Vue.nextTick().then(() => (this.$refs.labelInput as LabelInput).focus());
                 }
                 return;


### PR DESCRIPTION
This PR fixes a 'Cannot read property 'focus' of undefined` Error in `IdenticonSelector`.