### PR TITLE
Send credentials with the webhook

### DIFF
--- a/src/lib/CheckoutServerApi.ts
+++ b/src/lib/CheckoutServerApi.ts
@@ -91,12 +91,26 @@ export default class CheckoutServerApi {
             body:  requestData,
             mode: 'cors',
             cache: 'default',
-            credentials: 'omit',
+            credentials: 'include',
         };
 
-        const fetchRequest = new Request(endPoint, init);
+        let fetchResponse;
+        try {
+            // First we try to send the request with 'credentials: include', which includes cookies
+            // and auth headers in cross-origin requests, but in turn requires the server to set
+            // the 'Access-Control-Allow-Credentials: true' header.
+            const fetchRequest = new Request(endPoint, init);
+            fetchResponse = await fetch(fetchRequest);
+        } catch(err) {
+            // If the previous request with included credentials fails, we try again with the
+            // credentials omitted (default for cross-origin requests). Some implementations might
+            // not have the header set, because they don't require cookies or auth headers for
+            // authenticating the webhook.
+            delete init.credentials;
+            const fetchRequest = new Request(endPoint, init);
+            fetchResponse = await fetch(fetchRequest);
+        }
 
-        const fetchResponse = await fetch(fetchRequest);
         if (!fetchResponse.ok) {
             throw new Error(`${fetchResponse.status} - ${fetchResponse.statusText}`);
         }

--- a/src/lib/CheckoutServerApi.ts
+++ b/src/lib/CheckoutServerApi.ts
@@ -101,7 +101,7 @@ export default class CheckoutServerApi {
             // the 'Access-Control-Allow-Credentials: true' header.
             const fetchRequest = new Request(endPoint, init);
             fetchResponse = await fetch(fetchRequest);
-        } catch(err) {
+        } catch (err) {
             // If the previous request with included credentials fails, we try again with the
             // credentials omitted (default for cross-origin requests). Some implementations might
             // not have the header set, because they don't require cookies or auth headers for


### PR DESCRIPTION
To support various e-commerce authentication systems, we should allow to send credentials (cookies and auth headers) with the webhook request. However, because including the credentials requires the server to answer with a specific header (as per CORS rules), this might fail if the server omits this header. We then simply try again with the credentials omitted.