### PR TITLE
Allow external recipient label for sign-transaction requests

### DIFF
--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -30,6 +30,7 @@ export interface SignTransactionRequest extends BasicRequest {
     sender: string;
     recipient: string;
     recipientType?: Nimiq.Account.Type;
+    recipientLabel?: string;
     value: number;
     fee?: number;
     extraData?: Uint8Array | string;

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -42,6 +42,7 @@ export class RequestParser {
                     sender: Nimiq.Address.fromUserFriendlyAddress(signTransactionRequest.sender),
                     recipient: Nimiq.Address.fromUserFriendlyAddress(signTransactionRequest.recipient),
                     recipientType: signTransactionRequest.recipientType || Nimiq.Account.Type.BASIC,
+                    recipientLabel: signTransactionRequest.recipientLabel,
                     value: signTransactionRequest.value,
                     fee: signTransactionRequest.fee || 0,
                     data: typeof signTransactionRequest.extraData === 'string'
@@ -163,6 +164,7 @@ export class RequestParser {
                     sender: signTransactionRequest.sender.toUserFriendlyAddress(),
                     recipient: signTransactionRequest.recipient.toUserFriendlyAddress(),
                     recipientType: signTransactionRequest.recipientType,
+                    recipientLabel: signTransactionRequest.recipientLabel,
                     value: signTransactionRequest.value,
                     fee: signTransactionRequest.fee,
                     extraData: signTransactionRequest.data,

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -32,6 +32,7 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     sender: Nimiq.Address;
     recipient: Nimiq.Address;
     recipientType: Nimiq.Account.Type;
+    recipientLabel?: string;
     value: number;
     fee: number;
     data: Uint8Array;

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -35,7 +35,7 @@ export default class SignTransaction extends Vue {
             senderLabel: (senderContract || signer).label,
             recipient: this.request.recipient.serialize(),
             recipientType: this.request.recipientType,
-            recipientLabel: undefined, // XXX Should we accept a recipient label from outside?
+            recipientLabel: this.request.recipientLabel,
             value: this.request.value,
             fee: this.request.fee,
             validityStartHeight: this.request.validityStartHeight,


### PR DESCRIPTION
Forward recipient label to Keyguard to display there.

This was previously part of the `sebastian/cashlink-create-manage` branch.