### PR TITLE
Logo simplification and mobile close-button alignment

### DIFF
--- a/public/blocking.css
+++ b/public/blocking.css
@@ -57,7 +57,7 @@ body {
 }
 
 .nq-icon.nimiq-logo {
-    background-image: url('data:image/svg+xml,<svg width="27" height="24" viewBox="0 0 27 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M26.6991 10.875L21.0741 1.125C20.6691 0.4275 19.9266 0 19.1241 0H7.87414C7.07164 0 6.32914 0.4275 5.92789 1.125L0.302891 10.875C-0.0983594 11.5725 -0.0983594 12.4275 0.302891 13.125L5.92789 22.875C6.32914 23.5725 7.07164 24 7.87414 24H19.1241C19.9266 24 20.6691 23.5725 21.0704 22.875L26.6954 13.125C27.1004 12.4275 27.1004 11.5725 26.6991 10.875Z" fill="url(%23paint0_radial)"/><defs><radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(26.9996 24) rotate(-180) scale(26.9977 24)"><stop stop-color="%23EC991C"/><stop offset="1" stop-color="%23E9B213"/></radialGradient></defs></svg>');
+    background-image: url('data:image/svg+xml,<svg width="27" height="24" viewBox="0 0 27 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M26.7 10.88l-5.63-9.76A2.25 2.25 0 0 0 19.12 0H7.87c-.8 0-1.54.43-1.94 1.13L.3 10.88c-.4.7-.4 1.55 0 2.24l5.63 9.76c.4.7 1.14 1.12 1.94 1.12h11.25c.8 0 1.55-.43 1.95-1.13l5.63-9.75c.4-.7.4-1.55 0-2.24z" fill="url(%23paint0_radial)"/><defs><radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-26.9977 0 0 -24 27 24)"><stop stop-color="%23EC991C"/><stop offset="1" stop-color="%23E9B213"/></radialGradient></defs></svg>');
 }
 
 .logo {

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,7 +102,7 @@ export default class App extends Vue {
         .global-close {
             position: absolute;
             right: 1rem;
-            top: 2.5rem;
+            top: 2rem;
             margin: 0;
         }
 


### PR DESCRIPTION
This reduces the logo byte-size and properly aligns the global-close button with the logo on mobile.

This was previously part of the `sebastian/cashlink-create-manage` branch.