### PR TITLE
Move extraData from MultiCurrencyCheckoutRequest.extraData to NimiqDirectPaymentOptions.protocolSpecific.extraData.

### DIFF
--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -277,7 +277,6 @@ class Demo {
                 callbackUrl: `${location.origin}/callback.html`,
                 csrf: 'dummy-csrf-token',
                 time: now,
-                extraData: 'Test MultiCheckout',
                 fiatCurrency: 'EUR',
                 fiatAmount: 24.99,
                 paymentOptions: [
@@ -298,6 +297,7 @@ class Demo {
                         expires: + new Date(now + 15 * 60000), // 15 minutes
                         protocolSpecific: {
                             fee: 50000,
+                            extraData: 'Test MultiCheckout',
                         },
                     },
                     {

--- a/src/components/CheckoutManualPaymentDetails.vue
+++ b/src/components/CheckoutManualPaymentDetails.vue
@@ -90,7 +90,7 @@ class CheckoutManualPaymentDetails<
         paymentInfoLine.setTime(serverTime);
     }
 }
-namespace CheckoutManualPaymentDetails { // tslint:disable-line:no-namespace
+namespace CheckoutManualPaymentDetails {
     export enum Events {
         CLOSE = 'close',
     }

--- a/src/components/CheckoutOption.vue
+++ b/src/components/CheckoutOption.vue
@@ -126,8 +126,12 @@ export default class CheckoutOption<
         if (!this.request.callbackUrl || !this.request.csrf) {
             throw new Error('Can\'t fetch payment details without callbackUrl and csrf token');
         }
-        fetchedData = await CheckoutServerApi.fetchPaymentOption(this.request.callbackUrl, this.paymentOptions.currency,
-            this.paymentOptions.type, this.request.csrf);
+        fetchedData = await CheckoutServerApi.fetchPaymentOption(
+            this.request.callbackUrl,
+            this.paymentOptions.currency,
+            this.paymentOptions.type,
+            this.request.csrf,
+        );
 
         // @ts-ignore: Call signatures for generic union types are not currently supported, see
         // https://github.com/microsoft/TypeScript/issues/30613 and
@@ -145,7 +149,7 @@ export default class CheckoutOption<
     protected async setupTimeout() {
         window.clearTimeout(this.optionTimeout);
         const referenceTime = Date.now() + (await this.timeOffsetPromise); // as a side effect ensures lastPaymentState
-        if (!this.paymentOptions.expires || this.lastPaymentState && this.lastPaymentState.payment_accepted) return;
+        if (!this.paymentOptions.expires || (this.lastPaymentState && this.lastPaymentState.payment_accepted)) return;
         const timeLeft = this.paymentOptions.expires - referenceTime;
         if (timeLeft > 0) {
             this.optionTimeout = window.setTimeout(

--- a/src/components/CurrencyInfo.vue
+++ b/src/components/CurrencyInfo.vue
@@ -39,7 +39,7 @@ class CurrencyInfo extends Vue {
     }
 }
 
-namespace CurrencyInfo { // tslint:disable-line:no-namespace
+namespace CurrencyInfo {
     export const Currency = PublicCurrency;
 }
 

--- a/src/components/NimiqCheckoutOption.vue
+++ b/src/components/NimiqCheckoutOption.vue
@@ -349,7 +349,7 @@ class NimiqCheckoutOption
                     recipientType: this.paymentOptions.protocolSpecific.recipientType,
                     // recipientLabel: '', // Checkout is using the shopOrigin instead
                     value: this.paymentOptions.amount,
-                    fee: this.paymentOptions.protocolSpecific.fee || 0,
+                    fee: this.paymentOptions.fee,
                     validityStartHeight,
                     data: this.paymentOptions.protocolSpecific.extraData,
                     flags: this.paymentOptions.protocolSpecific.flags,

--- a/src/components/NimiqCheckoutOption.vue
+++ b/src/components/NimiqCheckoutOption.vue
@@ -16,7 +16,7 @@
                 @main-action="statusScreenMainAction"
                 :mainAction="statusScreenMainActionText"
             >
-                <template v-if="timeoutReached || paymentState === PaymentState.UNDERPAID" v-slot:warning>
+                <template v-if="timeoutReached || paymentState === constructor.PaymentState.UNDERPAID" v-slot:warning>
                     <StopwatchIcon v-if="timeoutReached" class="stopwatch-icon"/>
                     <UnderPaymentIcon v-else class="under-payment-icon"/>
                     <h1 class="title nq-h1">{{ statusScreenTitle }}</h1>
@@ -98,7 +98,7 @@ import {
 import { AccountInfo } from '../lib/AccountInfo';
 import { TX_VALIDITY_WINDOW } from '../lib/Constants';
 import { ContractInfo, VestingContractInfo } from '../lib/ContractInfo';
-import { Account, Currency, PaymentState, RequestType } from '../lib/PublicRequestTypes';
+import { Account, Currency, PaymentState as PublicPaymentState, RequestType } from '../lib/PublicRequestTypes';
 import staticStore from '../lib/StaticStore';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { WalletStore } from '../lib/WalletStore';
@@ -122,7 +122,7 @@ import CurrencyInfo from './CurrencyInfo.vue';
     TransferIcon,
     UnderPaymentIcon,
 }})
-export default class NimiqCheckoutOption
+class NimiqCheckoutOption
     extends CheckoutOption<ParsedNimiqDirectPaymentOptions> {
     private static readonly BALANCE_CHECK_STORAGE_KEY = 'nimiq_checkout_last_balance_check';
     @State private wallets!: WalletInfo[];
@@ -351,7 +351,7 @@ export default class NimiqCheckoutOption
                     value: this.paymentOptions.amount,
                     fee: this.paymentOptions.protocolSpecific.fee || 0,
                     validityStartHeight,
-                    data: this.request.data,
+                    data: this.paymentOptions.protocolSpecific.extraData,
                     flags: this.paymentOptions.protocolSpecific.flags,
 
                     fiatAmount: this.request.fiatAmount,
@@ -402,11 +402,13 @@ export default class NimiqCheckoutOption
             return null;
         }
     }
-
-    private data() {
-        return { PaymentState };
-    }
 }
+
+namespace NimiqCheckoutOption {
+    export const PaymentState = PublicPaymentState;
+}
+
+export default NimiqCheckoutOption;
 </script>
 
 <style scoped>

--- a/src/components/NonNimiqCheckoutOption.vue
+++ b/src/components/NonNimiqCheckoutOption.vue
@@ -19,7 +19,7 @@
                             @main-action="statusScreenMainAction"
                             :mainAction="statusScreenMainActionText"
                         >
-                            <template v-if="timeoutReached || paymentState === PaymentState.UNDERPAID" v-slot:warning>
+                            <template v-if="timeoutReached || paymentState === constructor.PaymentState.UNDERPAID" v-slot:warning>
                                 <StopwatchIcon v-if="timeoutReached" class="stopwatch-icon"/>
                                 <UnderPaymentIcon v-else class="under-payment-icon"/>
                                 <h1 class="title nq-h1">{{ statusScreenTitle }}</h1>
@@ -129,7 +129,7 @@ import {
     Amount,
     FiatAmount,
 } from '@nimiq/vue-components';
-import { PaymentState } from '../lib/PublicRequestTypes';
+import { PaymentState as PublicPaymentState } from '../lib/PublicRequestTypes';
 import { AvailableParsedPaymentOptions } from '../lib/RequestTypes';
 import CheckoutOption from './CheckoutOption.vue';
 import CurrencyInfo from './CurrencyInfo.vue';
@@ -152,7 +152,7 @@ import CheckoutManualPaymentDetails from './CheckoutManualPaymentDetails.vue';
     Amount,
     FiatAmount,
 }})
-export default class NonNimiqCheckoutOption<
+class NonNimiqCheckoutOption<
     Parsed extends AvailableParsedPaymentOptions
 > extends CheckoutOption<Parsed> {
     protected currencyFullName: string = ''; // to be set by child class
@@ -177,7 +177,7 @@ export default class NonNimiqCheckoutOption<
     }
 
     protected get paymentLink(): string {
-        throw new Error('Needs to be implemented by child classes.');
+        throw new Error('NonNimiqCheckoutOption.paymentLink() Needs to be implemented by child classes.');
     }
 
     protected async selectCurrency() {
@@ -224,11 +224,13 @@ export default class NonNimiqCheckoutOption<
             window.onblur = null;
         };
     }
-
-    private data() {
-        return { PaymentState };
-    }
 }
+
+namespace NonNimiqCheckoutOption {
+    export const PaymentState = PublicPaymentState;
+}
+
+export default NonNimiqCheckoutOption;
 </script>
 
 <style scoped>

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -135,6 +135,7 @@ export interface MultiCurrencyCheckoutRequest extends BasicRequest {
     csrf?: string;
     /**
      * The data to be included in the transaction. Ignored for `Currenct.BTC` and `Currency.ETH`.
+     * @deprecated use NimiqDirectPaymentOptions.protocolSpecific.extraData instead.
      */
     extraData?: Uint8Array | string;
     /**

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -53,7 +53,6 @@ export interface ParsedCheckoutRequest extends ParsedBasicRequest {
     shopLogoUrl?: string;
     callbackUrl?: string;
     csrf?: string;
-    data: Uint8Array;
     time: number;
     fiatCurrency?: string;
     fiatAmount?: number;

--- a/src/lib/paymentOptions/ParsedPaymentOptions.ts
+++ b/src/lib/paymentOptions/ParsedPaymentOptions.ts
@@ -16,7 +16,7 @@ export interface ParsedPaymentOptions<C extends Currency, T extends PaymentType>
     amount: number | BigInteger;
     expires?: number;
     constructor: ParsedPaymentOptionsForCurrencyAndType<C, T>;
-    new(options: PaymentOptionsForCurrencyAndType<C, T>, enforceDefaultValues?: boolean):
+    new(options: PaymentOptionsForCurrencyAndType<C, T>, allowUndefinedFees?: boolean):
         ParsedPaymentOptionsForCurrencyAndType<C, T>;
 }
 
@@ -51,7 +51,7 @@ implements ParsedPaymentOptions<C, T> {
         ...additionalArgs: any[]
     ) {
         // Parse to check validity. Do not enforce default values, since undefined values are not updated.
-        const parsedOptions = new this.constructor(options as any, false);
+        const parsedOptions = new this.constructor(options as any, true);
         this.amount = parsedOptions.amount; // amount must exist on all parsed options
         this.expires = parsedOptions.expires || this.expires;
         for (const key of

--- a/src/lib/paymentOptions/ParsedPaymentOptions.ts
+++ b/src/lib/paymentOptions/ParsedPaymentOptions.ts
@@ -16,7 +16,7 @@ export interface ParsedPaymentOptions<C extends Currency, T extends PaymentType>
     amount: number | BigInteger;
     expires?: number;
     constructor: ParsedPaymentOptionsForCurrencyAndType<C, T>;
-    new(options: PaymentOptionsForCurrencyAndType<C, T>, ...optionalArgs: any[]):
+    new(options: PaymentOptionsForCurrencyAndType<C, T>, enforceDefaultValues?: boolean):
         ParsedPaymentOptionsForCurrencyAndType<C, T>;
 }
 
@@ -50,7 +50,8 @@ implements ParsedPaymentOptions<C, T> {
         options: PaymentOptionsForCurrencyAndType<C, T>,
         ...additionalArgs: any[]
     ) {
-        const parsedOptions = new this.constructor(options as any, ...additionalArgs); // parse to check validity
+        // Parse to check validity. Do not enforce default values, since undefined values are not updated.
+        const parsedOptions = new this.constructor(options as any, false);
         this.amount = parsedOptions.amount; // amount must exist on all parsed options
         this.expires = parsedOptions.expires || this.expires;
         for (const key of

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -13,35 +13,35 @@
             @select="selectedCurrency = $event">
             <template v-for="paymentOptions of request.paymentOptions" v-slot:[paymentOptions.currency]>
                 <NimiqCheckoutOption
-                    v-if="paymentOptions.currency === Currency.NIM"
+                    v-if="paymentOptions.currency === constructor.Currency.NIM"
                     :paymentOptions="paymentOptions"
                     :key="paymentOptions.currency"
                     :class="{
                         confirmed: choosenCurrency === paymentOptions.currency,
-                        left: leftSlide === Currency.NIM,
-                        right: rightSlide === Currency.NIM
+                        left: leftSlide === constructor.Currency.NIM,
+                        right: rightSlide === constructor.Currency.NIM
                     }"
                     @chosen="chooseCurrency"
                     @expired="expired"/>
                 <EthereumCheckoutOption
-                    v-else-if="paymentOptions.currency === Currency.ETH"
+                    v-else-if="paymentOptions.currency === constructor.Currency.ETH"
                     :paymentOptions="paymentOptions"
                     :key="paymentOptions.currency"
                     :class="{
                         confirmed: choosenCurrency === paymentOptions.currency,
-                        left: leftSlide === Currency.ETH,
-                        right: rightSlide === Currency.ETH
+                        left: leftSlide === constructor.Currency.ETH,
+                        right: rightSlide === constructor.Currency.ETH
                     }"
                     @chosen="chooseCurrency"
                     @expired="expired"/>
                 <BitcoinCheckoutOption
-                    v-else-if="paymentOptions.currency === Currency.BTC"
+                    v-else-if="paymentOptions.currency === constructor.Currency.BTC"
                     :paymentOptions="paymentOptions"
                     :key="paymentOptions.currency"
                     :class="{
                         confirmed: choosenCurrency === paymentOptions.currency,
-                        left: leftSlide === Currency.BTC,
-                        right: rightSlide === Currency.BTC
+                        left: leftSlide === constructor.Currency.BTC,
+                        right: rightSlide === constructor.Currency.BTC
                     }"
                     @chosen="chooseCurrency"
                     @expired="expired"/>
@@ -76,7 +76,7 @@ import { ParsedCheckoutRequest } from '../lib/RequestTypes';
 import BitcoinCheckoutOption from '../components/BitcoinCheckoutOption.vue';
 import EthereumCheckoutOption from '../components/EthereumCheckoutOption.vue';
 import NimiqCheckoutOption from '../components/NimiqCheckoutOption.vue';
-import { Currency } from '../lib/PublicRequestTypes';
+import { Currency as PublicCurrency } from '../lib/PublicRequestTypes';
 import { State as RpcState } from '@nimiq/rpc';
 import { Static } from '../lib/StaticStore';
 import { ERROR_CANCELED } from '../lib/Constants';
@@ -89,16 +89,16 @@ import { ERROR_CANCELED } from '../lib/Constants';
     EthereumCheckoutOption,
     NimiqCheckoutOption,
 }})
-export default class Checkout extends Vue {
+class Checkout extends Vue {
     private static DISCLAIMER_CLOSED_COOKIE = 'checkout-disclaimer-closed';
 
     @Static private rpcState!: RpcState;
     @Static private request!: ParsedCheckoutRequest;
-    private choosenCurrency: Currency | null = null;
-    private selectedCurrency: Currency = Currency.NIM;
-    private leftSlide!: Currency;
-    private rightSlide!: Currency;
-    private availableCurrencies: Currency[] = [];
+    private choosenCurrency: PublicCurrency | null = null;
+    private selectedCurrency: PublicCurrency = Checkout.Currency.NIM;
+    private leftSlide!: PublicCurrency;
+    private rightSlide!: PublicCurrency;
+    private availableCurrencies: PublicCurrency[] = [];
     private readonly isIOS: boolean = BrowserDetection.isIOS();
     private disclaimerOverlayClosed: boolean = false;
     private screenFitsDisclaimer: boolean = true;
@@ -135,12 +135,12 @@ export default class Checkout extends Vue {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }
 
-    private chooseCurrency(currency: Currency) {
+    private chooseCurrency(currency: PublicCurrency) {
         this.selectedCurrency = currency;
         this.choosenCurrency = currency;
     }
 
-    private expired(currency: Currency) {
+    private expired(currency: PublicCurrency) {
         this.availableCurrencies.splice(this.availableCurrencies.indexOf(currency), 1);
     }
 
@@ -155,13 +155,13 @@ export default class Checkout extends Vue {
         const minHeight = 890; // Height at which two lines fit at bottom, also if logos over carousel shown.
         this.screenFitsDisclaimer = window.innerWidth >= minWidth && window.innerHeight >= minHeight;
     }
-
-    private data() {
-        return {
-            Currency,
-        };
-    }
 }
+
+namespace Checkout {
+    export const Currency = PublicCurrency;
+}
+
+export default Checkout;
 </script>
 
 <style scoped>

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -95,7 +95,7 @@ class Checkout extends Vue {
     @Static private rpcState!: RpcState;
     @Static private request!: ParsedCheckoutRequest;
     private choosenCurrency: PublicCurrency | null = null;
-    private selectedCurrency: PublicCurrency = Checkout.Currency.NIM;
+    private selectedCurrency: PublicCurrency = PublicCurrency.NIM;
     private leftSlide!: PublicCurrency;
     private rightSlide!: PublicCurrency;
     private availableCurrencies: PublicCurrency[] = [];

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -6,7 +6,7 @@
                 ref="info"
                 class="blur-target"
                 :cryptoAmount="{
-                    amount: checkoutPaymentOptions.amount + checkoutPaymentOptions.protocolSpecific.fee,
+                    amount: checkoutPaymentOptions.amount + checkoutPaymentOptions.fee,
                     currency: checkoutPaymentOptions.currency,
                     decimals: checkoutPaymentOptions.decimals,
                 }"
@@ -55,11 +55,11 @@
                 :maxDecimals="5"
             />
 
-            <div v-if="checkoutPaymentOptions ? checkoutPaymentOptions.protocolSpecific.fee : (cashlink || request).fee"
+            <div v-if="checkoutPaymentOptions ? checkoutPaymentOptions.fee : (cashlink || request).fee"
                 class="fee nq-text-s blur-target">
                 + <Amount
                     :amount="checkoutPaymentOptions
-                        ? checkoutPaymentOptions.protocolSpecific.fee
+                        ? checkoutPaymentOptions.fee
                         : (cashlink || request).fee"
                     :minDecimals="2" :maxDecimals="5"
                 /> fee
@@ -193,7 +193,7 @@ export default class SignTransactionLedger extends Vue {
         let value: number;
         let fee: number;
         let validityStartHeightPromise: Promise<number>;
-        let data: Uint8Array;
+        let data: Uint8Array | undefined;
         let flags: number;
         if (this.request.kind === RequestType.SIGN_TRANSACTION) {
             // direct sign transaction request invocation
@@ -232,8 +232,8 @@ export default class SignTransactionLedger extends Vue {
             }
 
             sender = Nimiq.Address.fromUserFriendlyAddress(this.$store.state.activeUserFriendlyAddress);
-            value = checkoutPaymentOptions.amount;
-            ({ recipient, fee, flags, extraData: data } = checkoutPaymentOptions.protocolSpecific);
+            ({ amount: value, fee } = checkoutPaymentOptions);
+            ({ recipient, flags, extraData: data } = checkoutPaymentOptions.protocolSpecific);
 
             this.recipientDetails = {
                 address: recipient.toUserFriendlyAddress(),

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -387,12 +387,9 @@ export default class SignTransactionLedger extends Vue {
         let data;
         let flags;
         if (this.request.kind === RequestType.SIGN_TRANSACTION) {
-            const signTransactionRequest = this.request as ParsedSignTransactionRequest;
-            data = signTransactionRequest.data;
-            flags = signTransactionRequest.flags;
+            ({data, flags} = this.request as ParsedSignTransactionRequest);
         } else {
-            data = this.checkoutPaymentOptions!.protocolSpecific.extraData;
-            flags = this.checkoutPaymentOptions!.protocolSpecific.flags;
+            ({extraData: data, flags} = this.checkoutPaymentOptions!.protocolSpecific);
         }
 
         if (!data || data.length === 0) {


### PR DESCRIPTION
This PR moves the extraData from `MultiCurrencyCheckout.extraData` to `NimiqDirectPaymntOptions.protoclSpecific.extraData` as it is only ever used in that case.

Additionally `fee`, `feePerByte` and `extraData` can now be `undefined` in `NimiqSpecifics` as `ParsedPaymentOptions.update()` determines the need for updating a value based on wether it is `undefined` or not. The constructor of `ParsedPaymentOptions` got a new argument `enforceDefaultValues` to account for the change.