### PR TITLE
Use URLSearchParams for callback request data

### DIFF
--- a/src/lib/CheckoutServerApi.ts
+++ b/src/lib/CheckoutServerApi.ts
@@ -32,7 +32,7 @@ export default class CheckoutServerApi {
             // Retrieve the data from state if already fetched
             fetchedData = history.state[currency];
         } else {
-            const requestData = new FormData();
+            const requestData = new URLSearchParams();
             requestData.append('currency', currency);
             requestData.append('command', 'set_currency');
             fetchedData = await CheckoutServerApi._fetchData(endPoint, requestData, csrfToken);
@@ -55,7 +55,7 @@ export default class CheckoutServerApi {
         currency: C,
         csrfToken: string,
     ): Promise<GetStateResponse> {
-        const data = new FormData();
+        const data = new URLSearchParams();
         data.append('currency', currency);
         data.append('command', 'get_state');
         if (CheckoutServerApi._getStatePromises.has(currency)) {
@@ -82,13 +82,13 @@ export default class CheckoutServerApi {
 
     private static _getStatePromises = new Map<Currency, Promise<GetStateResponse>>();
 
-    private static async _fetchData(endPoint: string, requestData: FormData, csrfToken: string): Promise<any> {
+    private static async _fetchData(endPoint: string, requestData: URLSearchParams, csrfToken: string): Promise<any> {
         requestData.append('csrf', csrfToken);
         const headers = new Headers();
         const init: RequestInit = {
             method: 'POST',
             headers,
-            body:  requestData,
+            body: requestData,
             mode: 'cors',
             cache: 'default',
             credentials: 'include',


### PR DESCRIPTION
To encode in `application/x-www-form-urlencoded` format instead of `multipart/form-data`. URL-encoded form data is easier to handle by servers and favored to use for plain-text payloads. Multipart data should only be used for binary files like images.

**I have already deployed this change to the Testnet Hub** and tested it with both the CheckoutService and the WooCommerce plugin and both work with this change without requiring any server-side changes.

## Background
When debugging why the webhook in the CheckoutService did not work, I found that [Google Cloud Functions are not natively able to handle `multipart/form-data`](https://cloud.google.com/functions/docs/writing/http#handling_content_types). Thus I wondered why the Hub is sending the webhook POST data as `multipart/form-data` instead of URL-encoded, [which would be the regular behavior for forms](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Sending_and_retrieving_form_data#The_enctype_attribute). With the help of StackOverflow I found that using `FormData` to assemble the data _implicitely_ submits the data as `multipart/form-data`, and that by using `URLSearchParams` (which have the same interface) the data is automatically sent as `application/x-www-form-urlencoded`.