### PR TITLE
Fix client type export

### DIFF
--- a/client/HubApi.ts
+++ b/client/HubApi.ts
@@ -26,12 +26,17 @@ import {
     CreateCashlinkRequest,
     ManageCashlinkRequest,
     Cashlink,
+    CashlinkState,
     CashlinkTheme,
 } from '../src/lib/PublicRequestTypes';
 
 export default class HubApi<DB extends BehaviorType = BehaviorType.POPUP> { // DB: Default Behavior
+    // Expose request behaviors and enums. Not exporting them via regular exports to avoid that users of the umd build
+    // have to use bundle['default'] to access the default export.
     public static readonly RequestType = RequestType;
     public static readonly RedirectRequestBehavior = RedirectRequestBehavior;
+    public static readonly PopupRequestBehavior = PopupRequestBehavior;
+    public static readonly CashlinkState = CashlinkState;
     public static readonly CashlinkTheme = CashlinkTheme;
     public static readonly MSG_PREFIX = '\x16Nimiq Signed Message:\n';
 

--- a/client/package.json
+++ b/client/package.json
@@ -7,8 +7,11 @@
   "author": "Nimiq Network Ltd.",
   "license": "Apache-2.0",
   "private": false,
+  "types": "types/index.d.ts",
   "dependencies": {
-    "@nimiq/rpc": "^0.3.0"
+    "@nimiq/core-web": "^1.5.3",
+    "@nimiq/rpc": "^0.3.0",
+    "big-integer": "^1.6.48"
   },
   "devDependencies": {
     "rollup": "^1.12.1",

--- a/client/types/Nimiq.d.ts
+++ b/client/types/Nimiq.d.ts
@@ -1,2 +1,1 @@
-// tslint:disable-next-line no-reference
-/// <reference path="../../node_modules/@nimiq/core-web/namespace.d.ts" />
+/// <reference path="../node_modules/@nimiq/core-web/namespace.d.ts" />

--- a/client/types/index.d.ts
+++ b/client/types/index.d.ts
@@ -1,1 +1,9 @@
-export * from '../dist/src/client/HubApi';
+// Import @nimiq/core-web types from relative path within user's node_modules
+/// <reference path="../../core-web/namespace.d.ts" />
+
+export { default } from '../dist/src/client/HubApi';
+
+// export public request types and RequestBehavior types for convenience of the HupApi user
+export * from '../dist/src/src/lib/PublicRequestTypes';
+export { RequestType } from '../dist/src/src/lib/RequestTypes';
+export { PopupRequestBehavior, RedirectRequestBehavior } from '../dist/src/client/RequestBehavior';

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -18,6 +18,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@nimiq/core-web@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.5.3.tgz#f0a4de59394f210f2c2d9cda8ee35c716847d40e"
+  integrity sha512-W66SS9n3ygYgD52r1GJr1WtYYOkcZsqdtMmDCEwDvkrmeARnHs2sAvj77Wt4PQG8JA7GwK5svIJr6rGccCaekw==
+
 "@nimiq/rpc@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.3.0.tgz#654c05acccc193b7d79fb09b2faf2114945ff872"
@@ -106,6 +111,11 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+big-integer@^1.6.48:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
- Specifying "types" in package.json
- Adding `@nimiq/core-web` as a depencecy such that core types are included
- Adding big-integer as a dependency to include types
- Expose `PopupRequestBehavior` and `CashlinkState` enum
- Exporting `PublicRequestTypes` for convenience