### PR TITLE
Unrelayed tx caching

### DIFF
--- a/src/lib/Helpers.ts
+++ b/src/lib/Helpers.ts
@@ -6,6 +6,19 @@ import {
     ERROR_INVALID_NETWORK,
 } from '../lib/Constants';
 
+export function setHistoryStorage(key: string, data: any) {
+    // Note that data can be anything that can be structurally cloned:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+    history.replaceState({
+        ...history.state,
+        [key]: data,
+    }, '');
+}
+
+export function getHistoryStorage(key: string): any | undefined {
+    return history.state ? history.state[key] : undefined;
+}
+
 export const loadNimiq = async () => {
     await Nimiq.WasmHelper.doImport();
     let genesisConfigInitialized = true;


### PR DESCRIPTION
This PR enables resending transactions after reload of the page.
This has been a feature of `CashlinkManage` for Keyguard Cashlink transactions before but is now also supported for Ledger transactions (checkout and cashlink).
Additionally, `CashlinkManage` can now detect for Keyguard transactions whether they have already been sent or not, and does now not resend a transaction on reload anymore but forwards directly to the management screen.