### PR TITLE
Small network fixes

### DIFF
--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -134,14 +134,16 @@ class Network extends Vue {
         });
         client.relayTransaction(txObjToSend);
 
-        return new Promise<SignedTransaction>((resolve, reject) => {
-            this.$once('transaction-relayed', (txInfo: any) => {
+        return new Promise<SignedTransaction>((resolve) => {
+            const listener = (txInfo: any) => {
                 if (txInfo.hash !== base64Hash) return;
+                this.$off(Network.Events.TRANSACTION_RELAYED, listener);
                 unrelayedTransactionMap = getHistoryStorage(Network.HISTORY_KEY_UNRELAYED_TRANSACTIONS);
                 delete unrelayedTransactionMap[base64Hash];
                 setHistoryStorage(Network.HISTORY_KEY_UNRELAYED_TRANSACTIONS, unrelayedTransactionMap);
                 resolve(signedTx);
-            });
+            };
+            this.$on(Network.Events.TRANSACTION_RELAYED, listener);
         });
     }
 

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -180,8 +180,10 @@ class Network extends Vue {
     public async getBlockchainHeight(): Promise<number> {
         const client = await this.getNetworkClient();
         if (Network._hasOrSyncsOnTopOfConsensus) return client.headInfo.height;
-        return new Promise((resolve) => this.$once(Network.Events.CONSENSUS_ESTABLISHED,
-            () => resolve(client.headInfo.height)));
+        return new Promise((resolve) => this.$once(Network.Events.CONSENSUS_ESTABLISHED, () =>
+            // At the time of the consensus event, the new head is not populated yet. Therefore, instead of accessing
+            // client.headInfo we wait for the HEAD_CHANGE which is triggered immediately after CONSENSUS_ESTABLISHED
+            this.$once(Network.Events.HEAD_CHANGE, (head: { height: number }) => resolve(head.height))));
     }
 
     public async getBalances(addresses: string[]): Promise<Map<string, number>> {


### PR DESCRIPTION
Fixes two issues:
- Transaction relayed event listeners previously were removed even when it was another tx that was relayed. This way, `sendToNetwork` was not able to resolve anymore for one of the transactions, when two are sent at the same time.
- Previously, `getBlockchainHeight` reported one if called, before the consensus was established.