### PR TITLE
Automatically configure cdn

### DIFF
--- a/public/cashlink.html
+++ b/public/cashlink.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <script type="text/javascript" src="/browser-warning.js" defer></script>
-    <script src="https://cdn.nimiq-testnet.com/v1.5.3/web-offline.js" defer></script>
+    <script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
     <title>Nimiq Cashlink</title>
 
     <meta name="robots" content="noindex, follow">

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <script type="text/javascript" src="/browser-warning.js" defer></script>
-    <script src="https://cdn.nimiq-testnet.com/v1.5.3/web-offline.js" defer></script>
+    <script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
     <title>My Nimiq Accounts</title>
     <link href="/blocking.css" rel="stylesheet">
     <link rel="icon" href="<%= htmlWebpackPlugin.options.domain %>/favicon.ico">

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,6 +11,10 @@ const buildName = process.env.build
         ? 'testnet'
         : 'local';
 
+const cdnDomain = buildName === 'mainnet'
+    ? 'https://cdn.nimiq.com'
+    : 'https://cdn.nimiq-testnet.com';
+
 const domain = buildName === 'mainnet'
     ? 'https://hub.nimiq.com'
     : buildName === 'testnet'
@@ -55,6 +59,7 @@ const pages = {
         template: 'public/index.html',
         // insert browser warning html templates
         browserWarning,
+        cdnDomain,
         domain,
         // output as dist/index.html
         filename: 'index.html',
@@ -80,6 +85,7 @@ const pages = {
         template: 'public/cashlink.html',
         // insert browser warning html templates
         browserWarning,
+        cdnDomain,
         domain,
         // output as dist/cashlink/index.html
         filename: 'cashlink/index.html',


### PR DESCRIPTION
Automatically detect during build whether to use cdn.nimiq.com
or cdn.nimiq-testnet.com. This way, this doesn't need to be
manually configured / cherry-picked for mainnet builds anymore.