### PR TITLE
Update and customize browser warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/browser-warning": "^0.4.0",
+        "@nimiq/browser-warning": "^1.1.0",
         "@nimiq/iqons": "^1.5.0",
         "@nimiq/keyguard-client": "^1.0.0",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",

--- a/public/cashlink.html
+++ b/public/cashlink.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- Use no custom browser warning share behavior here as cashlink can be opened just fine in other browser. -->
     <script type="text/javascript" src="/browser-warning.js" defer></script>
     <script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
     <title>Nimiq Cashlink</title>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <script type="text/javascript" src="/browser-warning.js" defer></script>
+    <!-- On browser warning offer the caller url as shareUrl as opening the hub itself in a different browser or tab
+    doesn't make sense because the hub requires a request. Note that the snippet is written in old-fashioned Javascript
+    as required by the browser warnings and minified by hand as the HtmlWebpackPlugin only minifies html. -->
+    <script>window.onBrowserWarning=function(){var caller=document.referrer||window.opener;return{hasShareButton:caller,shareUrl:caller}}</script>
+    <script type="text/javascript" src="browser-warning.js" defer></script>
     <script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
     <title>My Nimiq Accounts</title>
     <link href="/blocking.css" rel="stylesheet">

--- a/src/cashlink.ts
+++ b/src/cashlink.ts
@@ -7,7 +7,7 @@ import { startSentry } from '@/lib/Helpers';
 import IqonsSvg from '@nimiq/iqons/dist/iqons.min.svg';
 
 if (window.hasBrowserWarning) {
-    throw new Error('Exeution aborted due to browser warning');
+    throw new Error('Execution aborted due to browser warning');
 }
 
 if ((BrowserDetection.isIOS() || BrowserDetection.isSafari()) && 'serviceWorker' in navigator) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { startSentry } from '@/lib/Helpers';
 import IqonsSvg from '@nimiq/iqons/dist/iqons.min.svg';
 
 if (window.hasBrowserWarning) {
-    throw new Error('Exeution aborted due to browser warning');
+    throw new Error('Execution aborted due to browser warning');
 }
 
 if ((BrowserDetection.isIOS() || BrowserDetection.isSafari()) && 'serviceWorker' in navigator) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "baseUrl": ".",
     "types": [
       "node",
-      "jest"
+      "jest",
+      "@nimiq/browser-warning"
     ],
     "paths": {
       "@/*": [
@@ -31,7 +32,6 @@
   },
   "include": [
     "types/Nimiq.d.ts",
-    "types/BrowserWarning.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.vue",

--- a/types/BrowserWarning.d.ts
+++ b/types/BrowserWarning.d.ts
@@ -1,3 +1,0 @@
-declare interface Window {
-    hasBrowserWarning: boolean
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,10 +680,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nimiq/browser-warning@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/browser-warning/-/browser-warning-0.4.0.tgz#82f9c88e75f85fbaab838e970d1f27ad506beefd"
-  integrity sha512-7NEqSzsYwNvLM4KpnGtmSppVJju0HWjrHtbRMWefaXDfugM6bCbMqVLc112Bm88EefPdISj1cTr0pcyZZOCzuQ==
+"@nimiq/browser-warning@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/browser-warning/-/browser-warning-1.1.0.tgz#f600b0bf73a91e2195e1e344f6bcd603b4d3f18e"
+  integrity sha512-18SdpZfnYTiwoPbBsTtnSqyIMSn6cupWwYoIIBQm5sPzh31ZlNrE/S3KkyGW8YShBGaCh39Z8XAMvuCIX/hNMg==
 
 "@nimiq/core-web@1.4.3":
   version "1.4.3"


### PR DESCRIPTION
Update to browser warning 1.0.0 which now provides a share button,
fixes issues with old browsers, updated the warning for Edge
browsers, adds types and is minified.
The share button is customized such that it shares the caller url
instead of the hub itself which wouldn't make sense as the hub
request would not be available anymore when opening in another
tab or browser. Cashlinks however are shared normally.