### PR TITLE
Reduce js build size by minification and extracting source maps

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -4,6 +4,8 @@ const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const path = require('path');
 const fs = require('fs');
 const browserWarning = fs.readFileSync(__dirname + '/node_modules/@nimiq/browser-warning/dist/browser-warning.html.template');
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
 
 const buildName = process.env.build
     ? process.env.build
@@ -30,6 +32,7 @@ const configureWebpack = {
             { from: 'node_modules/@nimiq/browser-warning/dist', to: './' },
         ]),
         new WriteFileWebpackPlugin(),
+        // new BundleAnalyzerPlugin(),
     ],
     // Resolve config for yarn build
     resolve: {

--- a/vue.config.js
+++ b/vue.config.js
@@ -38,10 +38,12 @@ const configureWebpack = {
         }
     },
     // Fix sourcemaps (https://www.mistergoodcat.com/post/the-joy-that-is-source-maps-with-vuejs-and-typescript)
-    devtool: 'eval-source-map',
+    devtool: process.env.NODE_ENV === 'development'
+        ? 'eval-source-map' // exact mapping; fast to build; large; disabled code minification and inlined maps
+        : 'source-map', // exact mapping; slow to build; small; enabled code minification and extracted maps
     output: {
         devtoolModuleFilenameTemplate: info => {
-            var $filename = 'sources://' + info.resourcePath;
+            let $filename = 'sources://' + info.resourcePath;
             if (info.resourcePath.match(/\.vue$/) && !info.query.match(/type=script/)) {
                 $filename = 'webpack-generated:///' + info.resourcePath + '?' + info.hash;
             }
@@ -100,9 +102,9 @@ if (buildName === 'local' || buildName === 'testnet') {
         // entry for the page
         entry: 'demos/Demo.ts',
         // the source template
-            template: 'demos/index.html',
-            // output as dist/index.html
-            filename: 'demos.html',
+        template: 'demos/index.html',
+        // output as dist/demos.html
+        filename: 'demos.html',
         // chunks to include on this page, by default includes
         // extracted common chunks and vendor chunks.
         chunks: ['chunk-vendors', 'chunk-common', 'demos']
@@ -138,4 +140,4 @@ module.exports = {
                 defaultAttribute: 'defer',
             }]);
     }
-}
+};


### PR DESCRIPTION
Greatly reduce bundle size by setting 'devtool' to 'source-map' instead
of 'eval-source-map' on production builds. This enables code minification
and extracts source maps into separate files. The javascript files are now
only ~14.3% of the previous size (~17.2% when comparing gzipped).

Resolves #306