### PR TITLE
Do not forward legacy wallet labels to Keyguard

### DIFF
--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -52,6 +52,10 @@ export class WalletInfo {
         return LabelingMachine.labelAccount(this.accounts.keys().next().value);
     }
 
+    public get labelForKeyguard(): string | undefined {
+        return this.type !== WalletType.LEGACY ? this.label : undefined;
+    }
+
     public findContractByAddress(address: Nimiq.Address): ContractInfo | undefined {
         return this.contracts.find((contract) => contract.address.equals(address));
     }

--- a/src/views/CashlinkCreate.vue
+++ b/src/views/CashlinkCreate.vue
@@ -408,7 +408,7 @@ class CashlinkCreate extends Vue {
                     appName: this.request.appName,
                     keyId: senderAccount.keyId,
                     keyPath: senderAccount.findSignerForAddress(this.accountOrContractInfo!.address)!.path,
-                    keyLabel: senderAccount.label,
+                    keyLabel: senderAccount.labelForKeyguard,
                     sender: this.accountOrContractInfo!.address.serialize(),
                     senderType: (this.accountOrContractInfo as ContractInfo).type
                         ? (this.accountOrContractInfo as ContractInfo).type

--- a/src/views/ChangePassword.vue
+++ b/src/views/ChangePassword.vue
@@ -17,7 +17,7 @@ export default class ChangePassword extends Vue {
         const request: KeyguardClient.SimpleRequest = {
             appName: this.request.appName,
             keyId: wallet.keyId,
-            keyLabel: wallet.label,
+            keyLabel: wallet.labelForKeyguard,
         };
 
         const client = this.$rpc.createKeyguardClient(true);

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -255,7 +255,7 @@ export default class Checkout extends Vue {
 
                     keyId: senderAccount.keyId,
                     keyPath: signer!.path,
-                    keyLabel: senderAccount.label,
+                    keyLabel: senderAccount.labelForKeyguard,
 
                     sender: (senderContract || signer).address.serialize(),
                     senderType: senderContract ? senderContract.type : Nimiq.Account.Type.BASIC,

--- a/src/views/Export.vue
+++ b/src/views/Export.vue
@@ -17,7 +17,7 @@ export default class Export extends Vue {
         const request: KeyguardClient.ExportRequest = {
             appName: this.request.appName,
             keyId: wallet.keyId,
-            keyLabel: wallet.label,
+            keyLabel: wallet.labelForKeyguard,
             fileOnly: this.request.fileOnly,
             wordsOnly: this.request.wordsOnly,
         };

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -17,7 +17,7 @@ export default class Logout extends Vue {
         const request: KeyguardClient.RemoveKeyRequest = {
             appName: this.request.appName,
             keyId: wallet.keyId,
-            keyLabel: wallet.label,
+            keyLabel: wallet.labelForKeyguard || wallet.accounts.values().next().value.label,
         };
 
         const client = this.$rpc.createKeyguardClient(true);

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -28,7 +28,7 @@ export default class SignTransaction extends Vue {
 
             keyId: senderAccount.keyId,
             keyPath: signer.path,
-            keyLabel: senderAccount.label,
+            keyLabel: senderAccount.labelForKeyguard,
 
             sender: (senderContract || signer).address.serialize(),
             senderType: senderContract ? senderContract.type : Nimiq.Account.Type.BASIC,


### PR DESCRIPTION
For a description of the problem this solves, see issue #260.

Resolves #260.