### PR TITLE
Fix error message to reflect what was not found

### DIFF
--- a/src/views/CashlinkCreate.vue
+++ b/src/views/CashlinkCreate.vue
@@ -278,7 +278,8 @@ class CashlinkCreate extends Vue {
             ? this.findWallet(walletId)
             : this.findWalletByAddress(address, true);
         if (!wallet) {
-            this.$rpc.reject(new Error('WalletId not found!'));
+            const errorMsg = walletId ? 'UNEXPECTED: WalletId not found!' : 'Address not found';
+            this.$rpc.reject(new Error(errorMsg));
             return;
         }
 
@@ -303,7 +304,7 @@ class CashlinkCreate extends Vue {
         let addresses: string[] = [];
         let accountsAndContracts: Array<AccountInfo | ContractInfo> = [];
 
-        if (!this.request.senderAddress) { // No senderAccount in the request
+        if (!this.request.senderAddress) { // No senderAddress in the request
             accountsAndContracts = wallets.reduce((acc, wallet) => {
                 acc.push(...wallet.accounts.values());
                 acc.push(...wallet.contracts);
@@ -315,7 +316,7 @@ class CashlinkCreate extends Vue {
         } else {
             const wallet = this.findWalletByAddress(this.request.senderAddress.toUserFriendlyAddress(), true);
             if (!wallet) {
-                this.$rpc.reject(new Error('WalletId not found!'));
+                this.$rpc.reject(new Error('Address not found!'));
                 return;
             }
 

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -54,7 +54,7 @@ export default class ChooseAddress extends Vue {
     private accountSelected(walletId: string, address: string) {
         const walletInfo = this.findWallet(walletId);
         if (!walletInfo) {
-            console.error('Selected account not found:', walletId);
+            console.error('UNEXPECTED: Selected walletId not found:', walletId);
             return;
         }
 

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -79,14 +79,14 @@ export default class SignMessage extends Vue {
             // Instead we quietly ignore any unavailable pre-set walletId and address and give
             // the user the option to chose as if it was not pre-set.
             this.showAccountSelector = true;
-            if (!isFromRequest) throw new Error(`UNEXPECTED: Selected walletId was not found: ${walletId}`);
+            if (!isFromRequest) throw new Error(`UNEXPECTED: Selected walletId not found: ${walletId}`);
             return;
         }
 
         const accountInfo = walletInfo.accounts.get(address);
         if (!accountInfo) {
             this.showAccountSelector = true;
-            if (!isFromRequest) throw new Error(`UNEXPECTED: Selected account was not found: ${address}`);
+            if (!isFromRequest) throw new Error(`UNEXPECTED: Selected account not found: ${address}`);
             return;
         }
 


### PR DESCRIPTION
#293 prompted me to review the error messages, so I did, and I found a few occurances where the wrong error message was thrown (e.g. when a wallet was searched for an address, but the wallet was not found, this means the address does not exist in the first place).