### PR TITLE
Rename *CheckoutOption to *CheckoutCard

### DIFF
--- a/src/components/BitcoinCheckoutCard.vue
+++ b/src/components/BitcoinCheckoutCard.vue
@@ -2,11 +2,11 @@
 import { createBitcoinRequestLink } from '@nimiq/utils';
 import staticStore from '../lib/StaticStore';
 import { ParsedBitcoinDirectPaymentOptions } from '../lib/paymentOptions/BitcoinPaymentOptions';
-import NonNimiqCheckoutOption from './NonNimiqCheckoutOption.vue';
+import NonNimiqCheckoutCard from './NonNimiqCheckoutCard.vue';
 import { FormattableNumber } from '@nimiq/utils';
 
-export default class BitcoinCheckoutOption
-    extends NonNimiqCheckoutOption<ParsedBitcoinDirectPaymentOptions> {
+export default class BitcoinCheckoutCard
+    extends NonNimiqCheckoutCard<ParsedBitcoinDirectPaymentOptions> {
     protected currencyFullName = 'Bitcoin';
     protected icon = 'icon-btc.svg';
 

--- a/src/components/CheckoutCard.vue
+++ b/src/components/CheckoutCard.vue
@@ -9,7 +9,7 @@ import { PaymentInfoLine } from '@nimiq/vue-components';
 import { ERROR_REQUEST_TIMED_OUT, HISTORY_KEY_SELECTED_CURRENCY } from '../lib/Constants';
 import { PaymentState } from '../lib/PublicRequestTypes';
 
-export default class CheckoutOption<
+export default class CheckoutCard<
     Parsed extends AvailableParsedPaymentOptions,
 > extends Vue {
     protected optionTimeout: number = -1;

--- a/src/components/EthereumCheckoutCard.vue
+++ b/src/components/EthereumCheckoutCard.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { createEthereumRequestLink } from '@nimiq/utils';
 import { ParsedEtherDirectPaymentOptions } from '../lib/paymentOptions/EtherPaymentOptions';
-import NonNimiqCheckoutOption from './NonNimiqCheckoutOption.vue';
+import NonNimiqCheckoutCard from './NonNimiqCheckoutCard.vue';
 import { FormattableNumber } from '@nimiq/utils';
 
-export default class EtherCheckoutOption
-    extends NonNimiqCheckoutOption<ParsedEtherDirectPaymentOptions> {
+export default class EtherCheckoutCard
+    extends NonNimiqCheckoutCard<ParsedEtherDirectPaymentOptions> {
     protected currencyFullName = 'Ethereum';
     protected icon = 'icon-eth.svg';
 

--- a/src/components/NimiqCheckoutCard.vue
+++ b/src/components/NimiqCheckoutCard.vue
@@ -108,7 +108,7 @@ import { WalletStore } from '../lib/WalletStore';
 import { ParsedNimiqDirectPaymentOptions } from '../lib/paymentOptions/NimiqPaymentOptions';
 import Network from './Network.vue';
 import StatusScreen from './StatusScreen.vue';
-import CheckoutOption from './CheckoutOption.vue';
+import CheckoutCard from './CheckoutCard.vue';
 import CurrencyInfo from './CurrencyInfo.vue';
 
 @Component({components: {
@@ -125,8 +125,8 @@ import CurrencyInfo from './CurrencyInfo.vue';
     TransferIcon,
     UnderPaymentIcon,
 }})
-class NimiqCheckoutOption
-    extends CheckoutOption<ParsedNimiqDirectPaymentOptions> {
+class NimiqCheckoutCard
+    extends CheckoutCard<ParsedNimiqDirectPaymentOptions> {
     private static readonly BALANCE_CHECK_STORAGE_KEY = 'nimiq_checkout_last_balance_check';
     @State private wallets!: WalletInfo[];
 
@@ -150,7 +150,7 @@ class NimiqCheckoutOption
 
     protected async created() {
         if (this.paymentOptions.currency !== Currency.NIM) {
-            throw new Error('NimiqCheckoutOption did not get a NimiqPaymentOption.');
+            throw new Error('NimiqCheckoutCard did not get a NimiqPaymentOption.');
         }
         return await super.created();
     }
@@ -258,7 +258,7 @@ class NimiqCheckoutOption
             height: this.height,
             balances: Array.from(balances.entries()),
         };
-        window.sessionStorage.setItem(NimiqCheckoutOption.BALANCE_CHECK_STORAGE_KEY, JSON.stringify(cacheInput));
+        window.sessionStorage.setItem(NimiqCheckoutCard.BALANCE_CHECK_STORAGE_KEY, JSON.stringify(cacheInput));
 
         return balances;
     }
@@ -418,7 +418,7 @@ class NimiqCheckoutOption
     }
 
     private getLastBalanceUpdateHeight(): {timestamp: number, height: number, balances: Map<string, number>} | null {
-        const rawCache = window.sessionStorage.getItem(NimiqCheckoutOption.BALANCE_CHECK_STORAGE_KEY);
+        const rawCache = window.sessionStorage.getItem(NimiqCheckoutCard.BALANCE_CHECK_STORAGE_KEY);
         if (!rawCache) return null;
 
         try {
@@ -431,17 +431,17 @@ class NimiqCheckoutOption
                 balances: new Map(cache.balances),
             });
         } catch (e) {
-            window.sessionStorage.removeItem(NimiqCheckoutOption.BALANCE_CHECK_STORAGE_KEY);
+            window.sessionStorage.removeItem(NimiqCheckoutCard.BALANCE_CHECK_STORAGE_KEY);
             return null;
         }
     }
 }
 
-namespace NimiqCheckoutOption {
+namespace NimiqCheckoutCard {
     export const PaymentState = PublicPaymentState;
 }
 
-export default NimiqCheckoutOption;
+export default NimiqCheckoutCard;
 </script>
 
 <style scoped>

--- a/src/components/NonNimiqCheckoutCard.vue
+++ b/src/components/NonNimiqCheckoutCard.vue
@@ -131,7 +131,7 @@ import {
 } from '@nimiq/vue-components';
 import { PaymentState as PublicPaymentState } from '../lib/PublicRequestTypes';
 import { AvailableParsedPaymentOptions } from '../lib/RequestTypes';
-import CheckoutOption from './CheckoutOption.vue';
+import CheckoutCard from './CheckoutCard.vue';
 import CurrencyInfo from './CurrencyInfo.vue';
 import StatusScreen from './StatusScreen.vue';
 import CheckoutManualPaymentDetails from './CheckoutManualPaymentDetails.vue';
@@ -152,9 +152,9 @@ import CheckoutManualPaymentDetails from './CheckoutManualPaymentDetails.vue';
     Amount,
     FiatAmount,
 }})
-class NonNimiqCheckoutOption<
+class NonNimiqCheckoutCard<
     Parsed extends AvailableParsedPaymentOptions
-> extends CheckoutOption<Parsed> {
+> extends CheckoutCard<Parsed> {
     protected currencyFullName: string = ''; // to be set by child class
     protected appNotFound: boolean = false;
 
@@ -177,7 +177,7 @@ class NonNimiqCheckoutOption<
     }
 
     protected get paymentLink(): string {
-        throw new Error('NonNimiqCheckoutOption.paymentLink() Needs to be implemented by child classes.');
+        throw new Error('NonNimiqCheckoutCard.paymentLink() Needs to be implemented by child classes.');
     }
 
     protected async selectCurrency() {
@@ -226,11 +226,11 @@ class NonNimiqCheckoutOption<
     }
 }
 
-namespace NonNimiqCheckoutOption {
+namespace NonNimiqCheckoutCard {
     export const PaymentState = PublicPaymentState;
 }
 
-export default NonNimiqCheckoutOption;
+export default NonNimiqCheckoutCard;
 </script>
 
 <style scoped>

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -12,7 +12,7 @@
             :disabled="choosenCurrency !== null || availableCurrencies.length === 0"
             @select="selectedCurrency = $event">
             <template v-for="paymentOptions of request.paymentOptions" v-slot:[paymentOptions.currency]>
-                <NimiqCheckoutOption
+                <NimiqCheckoutCard
                     v-if="paymentOptions.currency === constructor.Currency.NIM"
                     :paymentOptions="paymentOptions"
                     :key="paymentOptions.currency"
@@ -23,7 +23,7 @@
                     }"
                     @chosen="chooseCurrency"
                     @expired="expired"/>
-                <EthereumCheckoutOption
+                <EthereumCheckoutCard
                     v-else-if="paymentOptions.currency === constructor.Currency.ETH"
                     :paymentOptions="paymentOptions"
                     :key="paymentOptions.currency"
@@ -34,7 +34,7 @@
                     }"
                     @chosen="chooseCurrency"
                     @expired="expired"/>
-                <BitcoinCheckoutOption
+                <BitcoinCheckoutCard
                     v-else-if="paymentOptions.currency === constructor.Currency.BTC"
                     :paymentOptions="paymentOptions"
                     :key="paymentOptions.currency"
@@ -73,9 +73,9 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
 import { BottomOverlay, Carousel, ArrowLeftSmallIcon } from '@nimiq/vue-components';
 import { BrowserDetection } from '@nimiq/utils';
 import { ParsedCheckoutRequest } from '../lib/RequestTypes';
-import BitcoinCheckoutOption from '../components/BitcoinCheckoutOption.vue';
-import EthereumCheckoutOption from '../components/EthereumCheckoutOption.vue';
-import NimiqCheckoutOption from '../components/NimiqCheckoutOption.vue';
+import BitcoinCheckoutCard from '../components/BitcoinCheckoutCard.vue';
+import EthereumCheckoutCard from '../components/EthereumCheckoutCard.vue';
+import NimiqCheckoutCard from '../components/NimiqCheckoutCard.vue';
 import { Currency as PublicCurrency } from '../lib/PublicRequestTypes';
 import { State as RpcState } from '@nimiq/rpc';
 import { Static } from '../lib/StaticStore';
@@ -85,9 +85,9 @@ import { ERROR_CANCELED } from '../lib/Constants';
     ArrowLeftSmallIcon,
     BottomOverlay,
     Carousel,
-    BitcoinCheckoutOption,
-    EthereumCheckoutOption,
-    NimiqCheckoutOption,
+    BitcoinCheckoutCard,
+    EthereumCheckoutCard,
+    NimiqCheckoutCard,
 }})
 class Checkout extends Vue {
     private static DISCLAIMER_CLOSED_COOKIE = 'checkout-disclaimer-closed';


### PR DESCRIPTION
Renaming the components as I think having `*PaymentOptions` and `*CheckoutOptions` is too confusing.