### PR TITLE
RpcApi: Replace routerPush and routerReplace with navigation guards

### DIFF
--- a/src/components/NimiqCheckoutOption.vue
+++ b/src/components/NimiqCheckoutOption.vue
@@ -341,7 +341,7 @@ class NimiqCheckoutOption
         // proceed to transaction signing
         switch (senderAccount.type) {
             case WalletType.LEDGER:
-                this.$rpc.routerPush(`${RequestType.SIGN_TRANSACTION}-ledger`);
+                this.$router.push({name: `${RequestType.SIGN_TRANSACTION}-ledger`});
                 return;
             case WalletType.LEGACY:
             case WalletType.BIP39:
@@ -397,9 +397,9 @@ class NimiqCheckoutOption
         // Redirect to onboarding
         staticStore.originalRouteName = RequestType.CHECKOUT;
         if (useReplace) {
-            this.$rpc.routerReplace(RequestType.ONBOARD);
+            this.$router.replace({name: RequestType.ONBOARD});
         } else {
-            this.$rpc.routerPush(RequestType.ONBOARD);
+            this.$router.push({name: RequestType.ONBOARD});
         }
     }
 

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -92,20 +92,20 @@ export default class RpcApi {
         ]);
 
         this._router.beforeEach((to: Route, from: Route, next: (arg?: string | false | Route) => void) => {
-            // // There is an intial redirect from '/' to '/' which does not need to be handled at all.
+            // There is an intial redirect from '/' to '/' which does not need to be handled at all.
             if (to.name === REQUEST_ERROR || (to.path === '/' && from.path === '/')) {
                 next();
                 return;
             }
-            // If the target already has its rpcId, do not update it, since the caller to push()/replace()
-            // can provide it.
+
+            // If the navigation call already contains an rpcId, do not replace it.
             if ( to.query.rpcId ) {
                 next();
                 return;
             }
 
             const rpcId = from.query.rpcId || this._parseUrlParams(window.location.search).rpcId;
-            // In case no rpcId can be found the request is not functional and needs to be rejected.
+            // In case no rpcId can be found, the request is not functional and needs to be rejected.
             if (!rpcId) {
                 this.reject(new Error('UNEXPECTED: RpcId not present'));
                 next(false);
@@ -126,7 +126,7 @@ export default class RpcApi {
             if (to.path === '/' && from.path === '/') {
                 return;
             }
-            // In case there is an rpcState export the entire state to the newly pushed history entry
+            // If we have an rpcState, export the entire state to the newly pushed history entry
             // to be available on reload.
             // This is potentially redundand to the above condition but added as a precaution,
             // especially considering the no-request case a few lines down within RpcApi.start().

--- a/src/views/CashlinkCreate.vue
+++ b/src/views/CashlinkCreate.vue
@@ -398,7 +398,7 @@ class CashlinkCreate extends Vue {
         // proceed to transaction signing
         switch (senderAccount.type) {
             case WalletType.LEDGER:
-                this.$rpc.routerPush(`${RequestType.SIGN_TRANSACTION}-ledger`);
+                this.$router.push({name: `${RequestType.SIGN_TRANSACTION}-ledger`});
                 return;
             case WalletType.LEGACY:
             case WalletType.BIP39:
@@ -431,9 +431,9 @@ class CashlinkCreate extends Vue {
     private login(useReplace = false) {
         staticStore.originalRouteName = RequestType.CREATE_CASHLINK;
         if (useReplace) {
-            this.$rpc.routerReplace(RequestType.ONBOARD);
+            this.$router.replace({name: RequestType.ONBOARD});
         } else {
-            this.$rpc.routerPush(RequestType.ONBOARD);
+            this.$router.push({name: RequestType.ONBOARD});
         }
     }
 

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -78,9 +78,9 @@ export default class ChooseAddress extends Vue {
         // Redirect to onboarding
         staticStore.originalRouteName = RequestType.CHOOSE_ADDRESS;
         if (useReplace) {
-            this.$rpc.routerReplace(RequestType.ONBOARD);
+            this.$router.replace({name: RequestType.ONBOARD});
         }
-        this.$rpc.routerPush(RequestType.ONBOARD);
+        this.$router.push({name: RequestType.ONBOARD});
     }
 
     private close() {

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -57,7 +57,7 @@ export default class ErrorHandler extends Vue {
         }
 
         if (this.keyguardResult.message === Errors.Messages.GOTO_CREATE) {
-            this.$rpc.routerReplace(RequestType.SIGNUP);
+            this.$router.replace({name: RequestType.SIGNUP});
             return;
         }
 

--- a/src/views/ExportSuccess.vue
+++ b/src/views/ExportSuccess.vue
@@ -12,9 +12,9 @@ import { SmallPage, CheckmarkIcon } from '@nimiq/vue-components';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
 import { ExportResult, RequestType } from '../lib/PublicRequestTypes';
 import { State } from 'vuex-class';
-import staticStore, { Static } from '@/lib/StaticStore';
-import StatusScreen from '@/components/StatusScreen.vue';
-import { WalletStore } from '@/lib/WalletStore';
+import staticStore, { Static } from '../lib/StaticStore';
+import StatusScreen from '../components/StatusScreen.vue';
+import { WalletStore } from '../lib/WalletStore';
 import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component({components: {SmallPage, StatusScreen, CheckmarkIcon}})
@@ -79,7 +79,10 @@ export default class ExportSuccess extends Vue {
 
             // Recreate original URL with original query parameters
             const query = { rpcId: staticStore.rpcState!.id.toString() };
-            setTimeout(() => this.$rpc.routerPush(RequestType.MIGRATE, query), StatusScreen.SUCCESS_REDIRECT_DELAY);
+            setTimeout(() => this.$router.push({
+                name: RequestType.MIGRATE,
+                query,
+            }), StatusScreen.SUCCESS_REDIRECT_DELAY);
         }
     }
 }

--- a/src/views/OnboardingSelector.vue
+++ b/src/views/OnboardingSelector.vue
@@ -60,7 +60,7 @@ export default class OnboardingSelector extends Vue {
     }
 
     private ledger() {
-        this.$rpc.routerPush(`${RequestType.SIGNUP}-ledger`);
+        this.$router.push({name: `${RequestType.SIGNUP}-ledger`});
     }
 
     private close() {

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -121,9 +121,9 @@ export default class SignMessage extends Vue {
         // Redirect to onboarding
         staticStore.originalRouteName = RequestType.SIGN_MESSAGE;
         if (useReplace) {
-            this.$rpc.routerReplace(RequestType.ONBOARD);
+            this.$router.replace({name: RequestType.ONBOARD});
         } else {
-            this.$rpc.routerPush(RequestType.ONBOARD);
+            this.$router.push({name: RequestType.ONBOARD});
         }
     }
 

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -361,7 +361,7 @@ export default class SignTransactionLedger extends Vue {
             await new Promise((resolve) => setTimeout(resolve, StatusScreen.SUCCESS_REDIRECT_DELAY));
             this.$rpc.resolve(result);
         } else {
-            this.$rpc.routerReplace(RequestType.MANAGE_CASHLINK);
+            this.$router.replace({name: RequestType.MANAGE_CASHLINK});
         }
     }
 


### PR DESCRIPTION
This PR removes `RpcApi.routerPush()` and `RpcApi.routerReplace()`. They are replaced with navigation guards on the router. 

As a remark for future use, that does also mean, that future calls to `Vue.$router.push()` now take a path, i.e `Vue.$router.push('/sign-transaction')` as argument. If a named route is used `Vue.$router.push({name: 'sign-transaction'})` must be used. That is different from how `Vue.$rpc.routerPush()` worked before this PR.

I replaced all current occurrences.

resolves #371 