### PR TITLE
Use Address.fromString in all places

### DIFF
--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -202,8 +202,8 @@ class Network extends Vue {
 
         return contracts.map((contract) => new VestingContractInfo(
             CONTRACT_DEFAULT_LABEL_VESTING,
-            Nimiq.Address.fromUserFriendlyAddress(contract.address),
-            Nimiq.Address.fromUserFriendlyAddress(contract.owner),
+            Nimiq.Address.fromString(contract.address),
+            Nimiq.Address.fromString(contract.owner),
             contract.start,
             Nimiq.Policy.coinsToSatoshis(contract.stepAmount),
             contract.stepBlocks,

--- a/src/components/NimiqCheckoutCard.vue
+++ b/src/components/NimiqCheckoutCard.vue
@@ -305,7 +305,7 @@ class NimiqCheckoutCard
             this.showStatusScreen = true;
             await this.updateBalancePromise;
         }
-        const nimiqAddress = Nimiq.Address.fromUserFriendlyAddress(address);
+        const nimiqAddress = Nimiq.Address.fromString(address);
         const senderAccount = this.wallets.find((wallet: WalletInfo) => wallet.id === walletId)!;
         const senderContract = senderAccount.findContractByAddress(nimiqAddress);
         const signer = senderAccount.findSignerForAddress(nimiqAddress)!;

--- a/src/lib/Cashlink.ts
+++ b/src/lib/Cashlink.ts
@@ -124,7 +124,7 @@ class Cashlink {
     public static fromObject(object: CashlinkEntry): Cashlink {
         return new Cashlink(
             Nimiq.KeyPair.unserialize(new Nimiq.SerialBuffer(object.keyPair)),
-            Nimiq.Address.fromUserFriendlyAddress(object.address),
+            Nimiq.Address.fromString(object.address),
             object.value,
             object.fee,
             object.message,
@@ -356,7 +356,7 @@ class Cashlink {
         if (!balance) {
             throw new Error('Cannot claim, there is no balance in this link');
         }
-        const recipient = Nimiq.Address.fromUserFriendlyAddress(recipientAddress);
+        const recipient = Nimiq.Address.fromString(recipientAddress);
         const transaction = new Nimiq.ExtendedTransaction(this.address, Nimiq.Account.Type.BASIC,
             recipient, recipientType, balance - fee, fee, await this._getBlockchainHeight(),
             Nimiq.Transaction.Flag.NONE, CashlinkExtraData.CLAIMING);

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -56,8 +56,8 @@ export class RequestParser {
                 return {
                     kind: RequestType.SIGN_TRANSACTION,
                     appName: signTransactionRequest.appName,
-                    sender: Nimiq.Address.fromUserFriendlyAddress(signTransactionRequest.sender),
-                    recipient: Nimiq.Address.fromUserFriendlyAddress(signTransactionRequest.recipient),
+                    sender: Nimiq.Address.fromString(signTransactionRequest.sender),
+                    recipient: Nimiq.Address.fromString(signTransactionRequest.recipient),
                     recipientType: signTransactionRequest.recipientType || Nimiq.Account.Type.BASIC,
                     recipientLabel: signTransactionRequest.recipientLabel,
                     value: signTransactionRequest.value,
@@ -294,14 +294,14 @@ export class RequestParser {
                     kind: RequestType.SIGN_MESSAGE,
                     appName: signMessageRequest.appName,
                     signer: signMessageRequest.signer
-                        ? Nimiq.Address.fromUserFriendlyAddress(signMessageRequest.signer)
+                        ? Nimiq.Address.fromString(signMessageRequest.signer)
                         : undefined,
                     message: signMessageRequest.message,
                 } as ParsedSignMessageRequest;
             case RequestType.CREATE_CASHLINK:
                 const createCashlinkRequest = request as CreateCashlinkRequest;
                 const senderAddress = 'senderAddress' in createCashlinkRequest && !!createCashlinkRequest.senderAddress
-                    ? Nimiq.Address.fromUserFriendlyAddress(createCashlinkRequest.senderAddress)
+                    ? Nimiq.Address.fromString(createCashlinkRequest.senderAddress)
                     : undefined;
                 const senderBalance = 'senderBalance' in createCashlinkRequest
                     ? createCashlinkRequest.senderBalance
@@ -359,7 +359,7 @@ export class RequestParser {
                 return {
                     kind: RequestType.MANAGE_CASHLINK,
                     appName: manageCashlinkRequest.appName,
-                    cashlinkAddress: Nimiq.Address.fromUserFriendlyAddress(manageCashlinkRequest.cashlinkAddress),
+                    cashlinkAddress: Nimiq.Address.fromString(manageCashlinkRequest.cashlinkAddress),
                 } as ParsedManageCashlinkRequest;
             default:
                 return null;

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -348,7 +348,7 @@ export default class WalletInfoCollector {
             const accountInfo = existingAccountInfo || new AccountInfo(
                 newAccount.path,
                 LabelingMachine.labelAddress(newAccount.address),
-                Nimiq.Address.fromUserFriendlyAddress(newAccount.address),
+                Nimiq.Address.fromString(newAccount.address),
             );
             if (balance !== undefined) accountInfo.balance = balance;
             walletInfo.accounts.set(newAccount.address, accountInfo);
@@ -369,15 +369,15 @@ export default class WalletInfoCollector {
         const genesisVestingContracts = (await NetworkClient.Instance.getGenesisVestingContracts())
             .map((contract) => new VestingContractInfo(
                 CONTRACT_DEFAULT_LABEL_VESTING,
-                Nimiq.Address.fromUserFriendlyAddress(contract.address),
-                Nimiq.Address.fromUserFriendlyAddress(contract.owner),
+                Nimiq.Address.fromString(contract.address),
+                Nimiq.Address.fromString(contract.owner),
                 contract.start,
                 Nimiq.Policy.coinsToSatoshis(contract.stepAmount),
                 contract.stepBlocks,
                 Nimiq.Policy.coinsToSatoshis(contract.totalAmount),
             ));
 
-        const potentialVestingOwnerAddress = Nimiq.Address.fromUserFriendlyAddress(potentialOwner.address);
+        const potentialVestingOwnerAddress = Nimiq.Address.fromString(potentialOwner.address);
         const contracts = genesisVestingContracts
             .filter((contract) => contract.owner.equals(potentialVestingOwnerAddress));
 

--- a/src/lib/paymentOptions/NimiqPaymentOptions.ts
+++ b/src/lib/paymentOptions/NimiqPaymentOptions.ts
@@ -45,7 +45,7 @@ export class ParsedNimiqDirectPaymentOptions extends ParsedPaymentOptions<Curren
         let sender: Nimiq.Address | undefined;
         if (options.protocolSpecific.sender !== undefined) {
             try {
-                sender = Nimiq.Address.fromUserFriendlyAddress(options.protocolSpecific.sender);
+                sender = Nimiq.Address.fromString(options.protocolSpecific.sender);
             } catch (err) {
                 throw new Error('If provided, sender must be a valid user friendly address string');
             }
@@ -54,7 +54,7 @@ export class ParsedNimiqDirectPaymentOptions extends ParsedPaymentOptions<Curren
         let recipient: Nimiq.Address | undefined;
         if (options.protocolSpecific.recipient !== undefined) {
             try {
-                recipient = Nimiq.Address.fromUserFriendlyAddress(options.protocolSpecific.recipient);
+                recipient = Nimiq.Address.fromString(options.protocolSpecific.recipient);
             } catch (err) {
                 throw new Error('If provided, recipient must be a valid user friendly address string');
             }

--- a/src/views/AddAddressLedger.vue
+++ b/src/views/AddAddressLedger.vue
@@ -84,7 +84,7 @@ export default class AddAddressLedger extends Vue {
         this.addressesToSelectFrom = derivedAddressInfos.map((addressInfo) => new AccountInfo(
             addressInfo.keyPath,
             LabelingMachine.labelAddress(addressInfo.address),
-            Nimiq.Address.fromUserFriendlyAddress(addressInfo.address),
+            Nimiq.Address.fromString(addressInfo.address),
             0, // balance 0 because user selects from unused addresses
         ));
         this.state = AddAddressLedger.State.IDENTICON_SELECTION;

--- a/src/views/CashlinkCreate.vue
+++ b/src/views/CashlinkCreate.vue
@@ -284,7 +284,7 @@ class CashlinkCreate extends Vue {
         }
 
         this.accountOrContractInfo = wallet.accounts.get(address)
-            || wallet.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address))!;
+            || wallet.findContractByAddress(Nimiq.Address.fromString(address))!;
 
         // FIXME: Also handle active account we get from store
         this.$setActiveAccount({

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -59,7 +59,7 @@ export default class ChooseAddress extends Vue {
         }
 
         const accountOrContractInfo: AccountInfo | ContractInfo = walletInfo.accounts.get(address) ||
-            walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address))!;
+            walletInfo.findContractByAddress(Nimiq.Address.fromString(address))!;
 
         this.$setActiveAccount({
             walletId: walletInfo.id,

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -107,7 +107,7 @@
                 this.wallet!.accounts.set(address, addressInfo);
                 return;
             }
-            const contractInfo = this.wallet!.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address));
+            const contractInfo = this.wallet!.findContractByAddress(Nimiq.Address.fromString(address));
             if (contractInfo) {
                 contractInfo.label = label || contractInfo.defaultLabel;
                 this.wallet!.setContract(contractInfo);

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -231,7 +231,7 @@ export default class SignTransactionLedger extends Vue {
                 return;
             }
 
-            sender = Nimiq.Address.fromUserFriendlyAddress(this.$store.state.activeUserFriendlyAddress);
+            sender = Nimiq.Address.fromString(this.$store.state.activeUserFriendlyAddress);
             ({ amount: value, fee } = checkoutPaymentOptions);
             ({ recipient, flags, extraData: data } = checkoutPaymentOptions.protocolSpecific);
 
@@ -259,7 +259,7 @@ export default class SignTransactionLedger extends Vue {
                     + 'static store.'));
                 return;
             }
-            sender = Nimiq.Address.fromUserFriendlyAddress(this.$store.state.activeUserFriendlyAddress);
+            sender = Nimiq.Address.fromString(this.$store.state.activeUserFriendlyAddress);
             ({ recipient, value, fee } = this.cashlink!.getFundingDetails());
             validityStartHeightPromise = network.getBlockchainHeight().then((blockchainHeight) => blockchainHeight + 1);
             data = CASHLINK_FUNDING_DATA;

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -190,7 +190,7 @@ export default class SignupLedger extends Vue {
             this.accountsToSelectFrom = currentlyCheckedAccounts.map((account) => new AccountInfo(
                 account.path,
                 LabelingMachine.labelAddress(account.address),
-                Nimiq.Address.fromUserFriendlyAddress(account.address),
+                Nimiq.Address.fromString(account.address),
                 0, // balance 0 because if user has to select an account, it's gonna be an unused one
             ));
         }


### PR DESCRIPTION
Resolves #365.

The method `Nimiq.Address.fromString()` tries to read the input as a userfriendly address first, then as HEX and then as Base64. Because the userfriendly format is tried first, there is barely any performance penalty to this.