### PR TITLE
CheckoutServerApi: serve dummy data in development mode

### DIFF
--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -269,7 +269,7 @@ class Demo {
         }
 
         async function generateMultiCheckoutRequest(): Promise<CheckoutRequest> {
-            const now =  + new Date();
+            const now = Date.now();
             return {
                 version: 2,
                 appName: 'Accounts Demos',

--- a/src/lib/CheckoutServerApi.ts
+++ b/src/lib/CheckoutServerApi.ts
@@ -130,41 +130,54 @@ export default class CheckoutServerApi {
     }
 
     private static _generateDummyData(requestData: URLSearchParams) {
-        const now = Date.now();
-        const options = [
-            {
-                currency: Currency.BTC,
-                type: PaymentType.DIRECT,
-                amount: '.0002e8',
-                expires: now + 15 * 60000, // 15 minutes
-                protocolSpecific: {
-                    feePerByte: 2, // 2 sat per byte
-                    recipient: '17w6ar5SqXFGr786WjGHB8xyu48eujHaBe', // Unicef
+        if (requestData.get('command') === 'get_state') {
+            return {
+                time: Date.now(),
+
+                // Change these to true and PAID for simulating a successfull payment
+                payment_accepted: false,
+                payment_state: PaymentState.NOT_FOUND,
+            };
+        } else if (requestData.get('command') === 'set_currency') {
+            const now = Date.now();
+            const options = [
+                {
+                    currency: Currency.BTC,
+                    type: PaymentType.DIRECT,
+                    amount: '.0002e8',
+                    expires: now + 15 * 60000, // 15 minutes
+                    protocolSpecific: {
+                        feePerByte: 2, // 2 sat per byte
+                        recipient: '17w6ar5SqXFGr786WjGHB8xyu48eujHaBe', // Unicef
+                    },
                 },
-            },
-            {
-                currency: Currency.NIM,
-                type: PaymentType.DIRECT,
-                amount: '1e5',
-                expires: now + 15 * 60000, // 15 minutes
-                protocolSpecific: {
-                    fee: 50000,
-                    recipient: 'NQ09 VF5Y 1PKV MRM4 5LE1 55KV P6R2 GXYJ XYQF', // Nimiq foundation
+                {
+                    currency: Currency.NIM,
+                    type: PaymentType.DIRECT,
+                    amount: '1e5',
+                    expires: now + 15 * 60000, // 15 minutes
+                    protocolSpecific: {
+                        fee: 50000,
+                        recipient: 'NQ09 VF5Y 1PKV MRM4 5LE1 55KV P6R2 GXYJ XYQF', // Nimiq foundation
+                    },
                 },
-            },
-            {
-                currency: Currency.ETH,
-                type: PaymentType.DIRECT,
-                amount: '.0023e18',
-                expires: now + 15 * 60000, // 15 minutes
-                protocolSpecific: {
-                    gasLimit: 21000,
-                    gasPrice: '10000',
-                    recipient: '0xa4725d6477644286b354288b51122a808389be83', // the water project
+                {
+                    currency: Currency.ETH,
+                    type: PaymentType.DIRECT,
+                    amount: '.0023e18',
+                    expires: now + 15 * 60000, // 15 minutes
+                    protocolSpecific: {
+                        gasLimit: 21000,
+                        gasPrice: '10000',
+                        recipient: '0xa4725d6477644286b354288b51122a808389be83', // the water project
+                    },
                 },
-            },
-        ];
-        const requestedOption = options.find((option) => option.currency === requestData.get('currency'));
-        return Object.assign({ time: now }, requestedOption);
+            ];
+            const requestedOption = options.find((option) => option.currency === requestData.get('currency'));
+            return {
+                time: now,
+                ...requestedOption,
+            };
+        }
     }
 }


### PR DESCRIPTION
This PR proposes to add checkout dummy data similar to the snippet already in use by Matheo, Sebastian and me to actual code base in a safe way.
This removes the need to always apply the snippet as a patch or from a stash when needed and the extra care to not include it in commits or builds. Additionally, it makes testing / developing easier for third party devs, that would need to write their own snippet.

Might be sufficient to resolve https://github.com/nimiq/hub/issues/377.