### PR TITLE
NIM-less Checkout

### DIFF
--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -7,4 +7,5 @@ export default {
     privilegedOrigins: [ '*' ],
     redirectTarget: window.location.protocol + '//' + window.location.hostname + ':8080/demos.html',
     reportToSentry: false,
+    allowsCheckoutWithoutNim: (origin: string): boolean => true,
 };

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -7,5 +7,5 @@ export default {
     privilegedOrigins: [ '*' ],
     redirectTarget: window.location.protocol + '//' + window.location.hostname + ':8080/demos.html',
     reportToSentry: false,
-    allowsCheckoutWithoutNim: (origin: string): boolean => true,
+    checkoutWithoutNimOrigins: [ '*' ],
 };

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -13,7 +13,7 @@ export default {
     ],
     redirectTarget: 'https://safe.nimiq.com',
     reportToSentry: true,
-    allowsCheckoutWithoutNim: (origin: string): boolean => [
+    checkoutWithoutNimOrigins: [
         'https://vendor.cryptopayment.link',
-    ].includes(origin),
+    ],
 };

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -13,4 +13,7 @@ export default {
     ],
     redirectTarget: 'https://safe.nimiq.com',
     reportToSentry: true,
+    allowsCheckoutWithoutNim: (origin: string): boolean => [
+        'https://vendor.cryptopayment.link',
+    ].includes(origin),
 };

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -13,7 +13,7 @@ export default {
     ],
     redirectTarget: 'https://safe.nimiq-testnet.com',
     reportToSentry: true,
-    allowsCheckoutWithoutNim: (origin: string): boolean => [
+    checkoutWithoutNimOrigins: [
         'https://checkout-service-staging-0.web.app',
-    ].includes(origin),
+    ],
 };

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -13,4 +13,7 @@ export default {
     ],
     redirectTarget: 'https://safe.nimiq-testnet.com',
     reportToSentry: true,
+    allowsCheckoutWithoutNim: (origin: string): boolean => [
+        'https://checkout-service-staging-0.web.app',
+    ].includes(origin),
 };

--- a/src/lib/Helpers.ts
+++ b/src/lib/Helpers.ts
@@ -45,8 +45,8 @@ export const loadNimiq = async () => {
     }
 };
 
-export function isPriviledgedOrigin(origin: string) {
-    return Config.privilegedOrigins.includes(origin) || Config.privilegedOrigins.includes('*');
+export function includesOrigin(list: string[], origin: string) {
+    return list.includes(origin) || list.includes('*');
 }
 
 export function isDesktop() {

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -144,15 +144,11 @@ export class RequestParser {
                     }
 
                     if (!checkoutRequest.callbackUrl || typeof checkoutRequest.callbackUrl !== 'string') {
-                        if (checkoutRequest.paymentOptions.some(
-                            (option) => option.currency !== Currency.NIM,
-                            )) {
+                        if (checkoutRequest.paymentOptions.some((option) => option.currency !== Currency.NIM)) {
                             throw new Error('A callbackUrl: string is required for currencies other than NIM to ' +
                                 'monitor payments.');
                         }
-                        if (!checkoutRequest.paymentOptions.every(
-                                (option) => !!option.protocolSpecific.recipient,
-                            )) {
+                        if (!checkoutRequest.paymentOptions.every((option) => !!option.protocolSpecific.recipient)) {
                             throw new Error('A callbackUrl: string or all recipients must be provided');
                         }
                     } else {
@@ -206,13 +202,12 @@ export class RequestParser {
                                         case Currency.NIM:
                                             // Once extraData from MultiCurrencyCheckoutRequest is removed
                                             // the next few lines become obsolete.
-                                            if (!option.protocolSpecific.extraData) {
+                                            if (!option.protocolSpecific.extraData && checkoutRequest.extraData) {
+                                                console.warn('Usage of MultiCurrencyCheckoutRequest.extraData is'
+                                                + ' deprecated. Use NimiqDirectPaymentOptions.protocolSpecific'
+                                                + '.extraData instead');
+
                                                 option.protocolSpecific.extraData = checkoutRequest.extraData;
-                                                if (option.protocolSpecific.extraData) {
-                                                    console.warn('Usage of MultiCurrencyCheckoutRequest.extraData is'
-                                                        + ' deprecated. Use NimiqDirectPaymentOptions.protocolSpecific'
-                                                        + '.extraData instead');
-                                                }
                                             }
                                             return new ParsedNimiqDirectPaymentOptions(option);
                                         case Currency.ETH:
@@ -228,6 +223,8 @@ export class RequestParser {
                         }),
                     } as ParsedCheckoutRequest;
                 }
+
+                throw new Error('Invalid version: must be 1 or 2');
             case RequestType.ONBOARD:
                 const onboardRequest = request as OnboardRequest;
                 return {

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -36,6 +36,7 @@ import { ParsedNimiqDirectPaymentOptions } from './paymentOptions/NimiqPaymentOp
 import { ParsedEtherDirectPaymentOptions } from './paymentOptions/EtherPaymentOptions';
 import { ParsedBitcoinDirectPaymentOptions } from './paymentOptions/BitcoinPaymentOptions';
 import { Utf8Tools } from '@nimiq/utils';
+import config from 'config';
 
 export class RequestParser {
     public static parse(
@@ -118,9 +119,12 @@ export class RequestParser {
                 }
 
                 if (checkoutRequest.version === 2) {
-                    if (!checkoutRequest.paymentOptions.some((option) => option.currency === Currency.NIM)) {
-                        throw new Error('CheckoutRequest must provide a NIM paymentOption.');
+                    if (!config.allowsCheckoutWithoutNim(state.origin)) {
+                        if (!checkoutRequest.paymentOptions.some((option) => option.currency === Currency.NIM)) {
+                            throw new Error('CheckoutRequest must provide a NIM paymentOption.');
+                        }
                     }
+
                     if (!checkoutRequest.shopLogoUrl) {
                         throw new Error('shopLogoUrl: string is required'); // shop logo non optional in version 2
                     }

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -209,8 +209,8 @@ export class RequestParser {
                                             // the next few lines become obsolete.
                                             if (!option.protocolSpecific.extraData && checkoutRequest.extraData) {
                                                 console.warn('Usage of MultiCurrencyCheckoutRequest.extraData is'
-                                                + ' deprecated. Use NimiqDirectPaymentOptions.protocolSpecific'
-                                                + '.extraData instead');
+                                                    + ' deprecated. Use NimiqDirectPaymentOptions.protocolSpecific'
+                                                    + '.extraData instead');
 
                                                 option.protocolSpecific.extraData = checkoutRequest.extraData;
                                             }

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -27,7 +27,7 @@ import Cashlink from '@/lib/Cashlink';
 import CookieJar from '@/lib/CookieJar';
 import { captureException } from '@sentry/browser';
 import { ERROR_CANCELED } from './Constants';
-import { isPriviledgedOrigin } from '@/lib/Helpers';
+import { includesOrigin } from '@/lib/Helpers';
 import Config from 'config';
 import { setHistoryStorage, getHistoryStorage } from '@/lib/Helpers';
 
@@ -241,8 +241,10 @@ export default class RpcApi {
     private async _hubApiHandler(requestType: RequestType, state: RpcState, arg: RpcRequest) {
         let request;
 
-        // Check that a non-whitelisted request comes from a privileged origin
-        if (!this._3rdPartyRequestWhitelist.includes(requestType) && !isPriviledgedOrigin(state.origin)) {
+        if ( // Check that a non-whitelisted request comes from a privileged origin
+            !this._3rdPartyRequestWhitelist.includes(requestType)
+            && !includesOrigin(Config.privilegedOrigins, state.origin)
+        ) {
             state.reply(ResponseStatus.ERROR, new Error(`${state.origin} is unauthorized to call ${requestType}`));
             return;
         }

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -292,7 +292,7 @@ export default class RpcApi {
                 }
             } else if (requestType === RequestType.CHECKOUT) {
                 const checkoutRequest = request as ParsedCheckoutRequest;
-                // forceSender only applies to non-multi-currency checkouts.
+                // forceSender only applies to NIM-only checkouts.
                 if (checkoutRequest.paymentOptions.length === 1
                     && checkoutRequest.paymentOptions[0].currency === Currency.NIM) {
 

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -97,7 +97,7 @@ class Checkout extends Vue {
     @Static private rpcState!: RpcState;
     @Static private request!: ParsedCheckoutRequest;
     private choosenCurrency: PublicCurrency | null = null;
-    private selectedCurrency: PublicCurrency = PublicCurrency.NIM;
+    private selectedCurrency: PublicCurrency | null = null;
     private leftCard: PublicCurrency | null = null;
     private rightCard: PublicCurrency | null = null;
     private initialCurrencies: PublicCurrency[] = [];
@@ -109,6 +109,8 @@ class Checkout extends Vue {
 
     @Watch('selectedCurrency', { immediate: true })
     private updateUnselected() {
+        if (!this.selectedCurrency) return;
+
         const entries = this.request.paymentOptions.map((paymentOptions) => paymentOptions.currency);
         if (entries.length === 1) return;
 
@@ -132,6 +134,11 @@ class Checkout extends Vue {
             || history.state[HISTORY_KEY_SELECTED_CURRENCY] === currency,
         );
         this.availableCurrencies = [ ...this.initialCurrencies ];
+        if (this.availableCurrencies.includes(PublicCurrency.NIM)) {
+            this.selectedCurrency = PublicCurrency.NIM;
+        } else {
+            this.selectedCurrency = this.availableCurrencies[0];
+        }
         document.title = 'Nimiq Checkout';
         const lastDisclaimerClose = parseInt(window.localStorage[Checkout.DISCLAIMER_CLOSED_STORAGE_KEY], 10);
         this.disclaimerRecentlyClosed = !Number.isNaN(lastDisclaimerClose)

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -107,14 +107,12 @@ class Checkout extends Vue {
     private screenFitsDisclaimer: boolean = true;
     private dimensionsUpdateTimeout: number = -1;
 
-    @Watch('selectedCurrency', { immediate: true })
+    @Watch('selectedCurrency')
     private updateUnselected() {
-        if (!this.selectedCurrency) return;
-
         const entries = this.request.paymentOptions.map((paymentOptions) => paymentOptions.currency);
         if (entries.length === 1) return;
 
-        const indexSelected = entries.indexOf(this.selectedCurrency);
+        const indexSelected = entries.indexOf(this.selectedCurrency!);
         if (entries.length === 2) {
             // We have two cards. Determine whether the non selected is to the left or to the right.
             this.leftCard = indexSelected === 1 ? entries[0] : null;

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -219,7 +219,11 @@ export default class SignTransactionLedger extends Vue {
             if (checkoutRequest.callbackUrl && checkoutRequest.csrf) {
                 try {
                     const fetchedPaymentOptions = await CheckoutServerApi.fetchPaymentOption(
-                        checkoutRequest.callbackUrl, Currency.NIM, checkoutPaymentOptions.type, checkoutRequest.csrf);
+                        checkoutRequest.callbackUrl,
+                        checkoutPaymentOptions.currency,
+                        checkoutPaymentOptions.type,
+                        checkoutRequest.csrf,
+                    );
                     checkoutPaymentOptions.update(fetchedPaymentOptions);
                 } catch (e) {
                     this.$rpc.reject(e);
@@ -375,7 +379,7 @@ export default class SignTransactionLedger extends Vue {
         if (this.request.kind !== RequestType.CHECKOUT) return null;
         const checkoutRequest = this.request as ParsedCheckoutRequest;
         return checkoutRequest.paymentOptions.find(
-            (option) => option.currency === Currency.NIM,
+            (option) => option.currency === Currency.NIM, // TODO: Also handle BTC payments
         ) as ParsedNimiqDirectPaymentOptions;
     }
 


### PR DESCRIPTION
Adds a configuration option `allowsCheckoutWithoutNim: (origin: string) => boolean` that returns if a given origin is allowed to create Checkout requests without a NimPaymentOption.

For development, this is configured as always `true` by default, for the testnet this allows the CPL staging website, and for the mainnet this allows Checkout requests from non-API CPLs.

The only two necessary changes are in `RequestParser` lines 122-126, and in `Checkout.vue`, as the NIM currency is now not necessarily present anymore.