### PR TITLE
Move public types into client directory

### DIFF
--- a/client/HubApi.ts
+++ b/client/HubApi.ts
@@ -7,6 +7,7 @@ import {
 } from './RequestBehavior';
 import { RedirectRpcClient } from '@nimiq/rpc';
 import {
+    AccountType,
     RequestType,
     BasicRequest,
     SimpleRequest,
@@ -40,8 +41,7 @@ import {
     SetupSwapRequest,
     SetupSwapResult,
     RefundSwapRequest,
-} from '../src/lib/PublicRequestTypes';
-import { WalletType } from '../src/lib/Constants';
+} from './PublicRequestTypes';
 
 export default class HubApi<
     DB extends BehaviorType = BehaviorType.POPUP,
@@ -54,7 +54,7 @@ export default class HubApi<
     public static readonly RequestType = RequestType;
     public static readonly RedirectRequestBehavior = RedirectRequestBehavior;
     public static readonly PopupRequestBehavior = PopupRequestBehavior;
-    public static readonly AccountType = WalletType; // tslint:disable-line:variable-name
+    public static readonly AccountType = AccountType;
     public static readonly CashlinkState = CashlinkState;
     public static readonly CashlinkTheme = CashlinkTheme;
     public static readonly Currency = Currency;

--- a/client/PublicPaymentOptions.ts
+++ b/client/PublicPaymentOptions.ts
@@ -1,0 +1,31 @@
+import { PaymentOptions, Currency, PaymentType } from './PublicRequestTypes';
+
+export interface NimiqSpecifics {
+    fee?: number | string;
+    feePerByte?: number | string;
+    extraData?: Uint8Array | string;
+    validityDuration?: number;
+    flags?: number;
+    sender?: string;
+    forceSender?: boolean;
+    recipient?: string;
+    recipientType?: Nimiq.Account.Type;
+}
+
+export type NimiqDirectPaymentOptions = PaymentOptions<Currency.NIM, PaymentType.DIRECT>;
+
+export interface BitcoinSpecifics {
+    fee?: number | string;
+    feePerByte?: number | string;
+    recipient?: string;
+}
+
+export type BitcoinDirectPaymentOptions = PaymentOptions<Currency.BTC, PaymentType.DIRECT>;
+
+export interface EtherSpecifics {
+    gasLimit?: number | string;
+    gasPrice?: string;
+    recipient?: string;
+}
+
+export type EtherDirectPaymentOptions = PaymentOptions<Currency.ETH, PaymentType.DIRECT>;

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -1,11 +1,11 @@
-import type { WalletType } from './Constants';
-
-import type { NimiqSpecifics } from './paymentOptions/NimiqPaymentOptions';
-import type { NimiqDirectPaymentOptions } from './paymentOptions/NimiqPaymentOptions';
-import type { BitcoinSpecifics } from './paymentOptions/BitcoinPaymentOptions';
-import type { BitcoinDirectPaymentOptions } from './paymentOptions/BitcoinPaymentOptions';
-import type { EtherSpecifics } from './paymentOptions/EtherPaymentOptions';
-import type { EtherDirectPaymentOptions } from './paymentOptions/EtherPaymentOptions';
+import {
+    NimiqSpecifics,
+    NimiqDirectPaymentOptions,
+    BitcoinSpecifics,
+    BitcoinDirectPaymentOptions,
+    EtherSpecifics,
+    EtherDirectPaymentOptions,
+} from './PublicPaymentOptions';
 
 export enum RequestType {
     LIST = 'list',
@@ -34,6 +34,17 @@ export enum RequestType {
 }
 
 export type Bytes = Uint8Array | string;
+
+export enum AccountType {
+    LEGACY = 1,
+    BIP39 = 2,
+    LEDGER = 3,
+}
+
+export {
+    /** @deprecated Use AccountType instead */
+    AccountType as WalletType,
+};
 
 export interface BasicRequest {
     appName: string;
@@ -427,7 +438,7 @@ export type Contract = VestingContract | HashedTimeLockedContract;
 export interface Account {
     accountId: string;
     label: string;
-    type: WalletType;
+    type: AccountType;
     fileExported: boolean;
     wordsExported: boolean;
     addresses: Address[];

--- a/client/RequestBehavior.ts
+++ b/client/RequestBehavior.ts
@@ -1,6 +1,6 @@
 import { PostMessageRpcClient, RedirectRpcClient } from '@nimiq/rpc';
 import { BrowserDetection } from '@nimiq/utils';
-import { ResultByRequestType, RequestType } from '../src/lib/PublicRequestTypes';
+import { ResultByRequestType, RequestType } from './PublicRequestTypes';
 import translate from './i18n/i18n';
 
 export abstract class RequestBehavior<B extends BehaviorType> {

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -5,7 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 
 export default [
     {
-        input: 'build/client/HubApi.js',
+        input: 'build/HubApi.js',
         output: {
             file: 'dist/HubApi.umd.js',
             format: 'umd',
@@ -19,7 +19,7 @@ export default [
         plugins: [ json() ],
     },
     {
-        input: 'build/client/HubApi.js',
+        input: 'build/HubApi.js',
         output: {
             file: 'dist/HubApi.es.js',
             format: 'es',
@@ -33,7 +33,7 @@ export default [
         plugins: [ json() ],
     },
     {
-        input: 'build/client/HubApi.js',
+        input: 'build/HubApi.js',
         output: {
             file: 'dist/standalone/HubApi.standalone.umd.js',
             format: 'umd',
@@ -46,7 +46,7 @@ export default [
         plugins: [ resolve(), json(), terser() ],
     },
     {
-        input: 'build/client/HubApi.js',
+        input: 'build/HubApi.js',
         output: {
             file: 'dist/standalone/HubApi.standalone.es.js',
             format: 'es',

--- a/client/types/index.d.ts
+++ b/client/types/index.d.ts
@@ -1,9 +1,8 @@
 // Import @nimiq/core-web types from relative path within user's node_modules
 /// <reference path="../../core-web/namespace.d.ts" />
 
-export { default } from '../dist/src/client/HubApi';
+export { default } from '../dist/src/HubApi';
 
 // export public request types, RequestBehavior types and Account types for convenience of the HupApi user
-export * from '../dist/src/src/lib/PublicRequestTypes';
-export { PopupRequestBehavior, RedirectRequestBehavior } from '../dist/src/client/RequestBehavior';
-export { WalletType as AccountType } from '../dist/src/src/lib/Constants'
+export * from '../dist/src/PublicRequestTypes';
+export { PopupRequestBehavior, RedirectRequestBehavior } from '../dist/src/RequestBehavior';

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -16,7 +16,7 @@ import {
     CashlinkTheme,
     RequestType,
     SetupSwapRequest,
-} from '../src/lib/PublicRequestTypes';
+} from '../client/PublicRequestTypes';
 import { RedirectRequestBehavior, PopupRequestBehavior } from '../client/RequestBehavior';
 import { Utf8Tools } from '@nimiq/utils';
 import { WalletType } from '../src/lib/Constants';

--- a/src/CashlinkApp.vue
+++ b/src/CashlinkApp.vue
@@ -20,7 +20,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { LoadingSpinner } from '@nimiq/vue-components';
 import CashlinkReceive from './views/CashlinkReceive.vue';
-import { CashlinkTheme } from './lib/PublicRequestTypes';
+import { CashlinkTheme } from '../client/PublicRequestTypes';
 import { loadNimiq } from './lib/Helpers';
 
 import '@nimiq/style/nimiq-style.min.css';

--- a/src/components/CheckoutCard.vue
+++ b/src/components/CheckoutCard.vue
@@ -7,7 +7,7 @@ import StatusScreen from './StatusScreen.vue';
 import CheckoutServerApi, { GetStateResponse } from '../lib/CheckoutServerApi';
 import { PaymentInfoLine } from '@nimiq/vue-components';
 import { ERROR_REQUEST_TIMED_OUT, HISTORY_KEY_SELECTED_CURRENCY } from '../lib/Constants';
-import { PaymentState } from '../lib/PublicRequestTypes';
+import { PaymentState } from '../../client/PublicRequestTypes';
 
 export default class CheckoutCard<
     Parsed extends AvailableParsedPaymentOptions,

--- a/src/components/CheckoutCardExternal.vue
+++ b/src/components/CheckoutCardExternal.vue
@@ -137,7 +137,7 @@ import {
     Amount,
     FiatAmount,
 } from '@nimiq/vue-components';
-import { PaymentState as PublicPaymentState } from '../lib/PublicRequestTypes';
+import { PaymentState as PublicPaymentState } from '../../client/PublicRequestTypes';
 import { AvailableParsedPaymentOptions } from '../lib/RequestTypes';
 import CheckoutCard from './CheckoutCard.vue';
 import CurrencyInfo from './CurrencyInfo.vue';

--- a/src/components/CheckoutCardNimiq.vue
+++ b/src/components/CheckoutCardNimiq.vue
@@ -111,7 +111,7 @@ import {
 import { AccountInfo } from '../lib/AccountInfo';
 import { TX_VALIDITY_WINDOW, WalletType } from '../lib/Constants';
 import { ContractInfo, VestingContractInfo } from '../lib/ContractInfo';
-import { Account, Currency, PaymentState as PublicPaymentState, RequestType } from '../lib/PublicRequestTypes';
+import { Account, Currency, PaymentState as PublicPaymentState, RequestType } from '../../client/PublicRequestTypes';
 import staticStore from '../lib/StaticStore';
 import { WalletInfo } from '../lib/WalletInfo';
 import { WalletStore } from '../lib/WalletStore';

--- a/src/components/CurrencyInfo.vue
+++ b/src/components/CurrencyInfo.vue
@@ -20,7 +20,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
 import { FiatAmount } from '@nimiq/vue-components';
-import { Currency as PublicCurrency } from '../lib/PublicRequestTypes';
+import { Currency as PublicCurrency } from '../../client/PublicRequestTypes';
 
 @Component({components: {FiatAmount}})
 class CurrencyInfo extends Vue {

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { SignedTransaction } from '../lib/PublicRequestTypes';
+import { SignedTransaction } from '../../client/PublicRequestTypes';
 import { NetworkClient, DetailedPlainTransaction } from '@nimiq/network-client';
 import Config from 'config';
 import { loadNimiq, setHistoryStorage, getHistoryStorage } from '../lib/Helpers';

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,7 +1,7 @@
 import Cashlink from './lib/Cashlink';
 import { CashlinkStore } from './lib/CashlinkStore';
 import { loadNimiq } from './lib/Helpers';
-import { CashlinkState } from './lib/PublicRequestTypes';
+import { CashlinkState } from '../client/PublicRequestTypes';
 
 async function main() {
     await loadNimiq();

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -11,7 +11,7 @@ import {
     RequestType,
     AddBtcAddressesRequest,
     AddBtcAddressesResult,
-} from './lib/PublicRequestTypes';
+} from '../client/PublicRequestTypes';
 import Cashlink from './lib/Cashlink';
 import { CashlinkStore } from './lib/CashlinkStore';
 import { loadBitcoinJS } from './lib/bitcoin/BitcoinJSLoader';

--- a/src/lib/AccountInfo.ts
+++ b/src/lib/AccountInfo.ts
@@ -1,4 +1,4 @@
-import { Address } from './PublicRequestTypes';
+import { Address } from '../../client/PublicRequestTypes';
 import AddressUtils from './AddressUtils';
 import { labelAddress } from './LabelingMachine';
 

--- a/src/lib/Cashlink.ts
+++ b/src/lib/Cashlink.ts
@@ -1,7 +1,7 @@
 import { Utf8Tools } from '@nimiq/utils';
 import { DetailedPlainTransaction, NetworkClient } from '@nimiq/network-client';
 import { loadNimiq } from './Helpers';
-import { CashlinkState, CashlinkTheme } from './PublicRequestTypes';
+import { CashlinkState, CashlinkTheme } from '../../client/PublicRequestTypes';
 
 export const CashlinkExtraData = {
     FUNDING:  new Uint8Array([0, 130, 128, 146, 135]), // 'CASH'.split('').map(c => c.charCodeAt(0) + 63)

--- a/src/lib/CheckoutServerApi.ts
+++ b/src/lib/CheckoutServerApi.ts
@@ -1,4 +1,4 @@
-import { Currency, PaymentType, PaymentOptionsForCurrencyAndType, PaymentState } from './PublicRequestTypes';
+import { Currency, PaymentType, PaymentOptionsForCurrencyAndType, PaymentState } from '../../client/PublicRequestTypes';
 import { isMilliseconds } from './Helpers';
 
 export interface GetStateResponse {

--- a/src/lib/Constants.ts
+++ b/src/lib/Constants.ts
@@ -2,11 +2,7 @@
  * Sorted by context and alphabetically
  */
 
-export enum WalletType {
-    LEGACY = 1,
-    BIP39 = 2,
-    LEDGER = 3,
-}
+export { AccountType, WalletType } from '../../client/PublicRequestTypes';
 
 // Addresses
 export const DEFAULT_KEY_PATH = `m/44'/242'/0'/0'`;

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -1,4 +1,4 @@
-import { VestingContract, HashedTimeLockedContract, Contract } from './PublicRequestTypes';
+import { VestingContract, HashedTimeLockedContract, Contract } from '../../client/PublicRequestTypes';
 import AddressUtils from './AddressUtils';
 import { labelAddress } from './LabelingMachine';
 

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -5,8 +5,6 @@ import {
     CashlinkTheme,
     Currency,
     PaymentType,
-} from './PublicRequestTypes';
-import type {
     BasicRequest,
     CheckoutRequest,
     CreateCashlinkRequest,
@@ -24,7 +22,7 @@ import type {
     SignBtcTransactionRequest,
     SetupSwapRequest,
     RefundSwapRequest,
-} from './PublicRequestTypes';
+} from '../../client/PublicRequestTypes';
 import type {
     ParsedBasicRequest,
     ParsedCheckoutRequest,

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -1,4 +1,4 @@
-import type { Currency, PaymentType, RequestType, CashlinkTheme } from './PublicRequestTypes';
+import type { Currency, PaymentType, RequestType, CashlinkTheme } from '../../client/PublicRequestTypes';
 import type { ParsedPaymentOptions } from './paymentOptions/ParsedPaymentOptions';
 import type { ParsedNimiqSpecifics, ParsedNimiqDirectPaymentOptions } from './paymentOptions/NimiqPaymentOptions';
 import type { ParsedEtherSpecifics, ParsedEtherDirectPaymentOptions } from './paymentOptions/EtherPaymentOptions';

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -11,7 +11,7 @@ import {
     ParsedSignTransactionRequest,
 } from './RequestTypes';
 import { RequestParser } from './RequestParser';
-import { Currency, RequestType, RpcRequest, RpcResult } from './PublicRequestTypes';
+import { Currency, RequestType, RpcRequest, RpcResult } from '../../client/PublicRequestTypes';
 import { ParsedNimiqDirectPaymentOptions } from './paymentOptions/NimiqPaymentOptions';
 import {
     KeyguardClient,

--- a/src/lib/StaticStore.ts
+++ b/src/lib/StaticStore.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { createDecorator } from 'vue-class-component';
 import { ParsedRpcRequest } from './RequestTypes';
-import { RpcResult, RequestType } from './PublicRequestTypes';
+import { RpcResult, RequestType } from '../../client/PublicRequestTypes';
 import { State as RpcState } from '@nimiq/rpc';
 import { Request as KeyguardRequest } from '@nimiq/keyguard-client';
 import Cashlink from '../lib/Cashlink';

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -5,7 +5,7 @@ import {
     ContractInfoEntry,
     ContractInfoHelper,
 } from './ContractInfo';
-import { Account } from './PublicRequestTypes';
+import { Account } from '../../client/PublicRequestTypes';
 import { labelKeyguardAccount } from './LabelingMachine';
 import WalletInfoCollector from './WalletInfoCollector';
 import { WalletStore } from '../lib/WalletStore';

--- a/src/lib/paymentOptions/BitcoinPaymentOptions.ts
+++ b/src/lib/paymentOptions/BitcoinPaymentOptions.ts
@@ -1,20 +1,13 @@
-import { Currency, PaymentType, PaymentOptions } from '../PublicRequestTypes';
+import { BitcoinSpecifics, BitcoinDirectPaymentOptions } from '../../../client/PublicPaymentOptions';
+import { Currency, PaymentType } from '../../../client/PublicRequestTypes';
 import { ParsedPaymentOptions, PaymentOptionsParserFlags } from './ParsedPaymentOptions';
 import { toNonScientificNumberString } from '@nimiq/utils';
 import { i18n } from '../../i18n/i18n-setup';
-
-export interface BitcoinSpecifics {
-    fee?: number | string;
-    feePerByte?: number | string;
-    recipient?: string;
-}
 
 export type ParsedBitcoinSpecifics = Pick<BitcoinSpecifics, 'recipient'> & {
     fee?: number;
     feePerByte?: number;
 };
-
-export type BitcoinDirectPaymentOptions = PaymentOptions<Currency.BTC, PaymentType.DIRECT>;
 
 export class ParsedBitcoinDirectPaymentOptions extends ParsedPaymentOptions<Currency.BTC, PaymentType.DIRECT> {
     public amount: number;

--- a/src/lib/paymentOptions/EtherPaymentOptions.ts
+++ b/src/lib/paymentOptions/EtherPaymentOptions.ts
@@ -1,21 +1,14 @@
 import bigInt from 'big-integer';
-import { Currency, PaymentType, PaymentOptions } from '../PublicRequestTypes';
+import { EtherSpecifics, EtherDirectPaymentOptions } from '../../../client/PublicPaymentOptions';
+import { Currency, PaymentType } from '../../../client/PublicRequestTypes';
 import { ParsedPaymentOptions, PaymentOptionsParserFlags } from './ParsedPaymentOptions';
 import { toNonScientificNumberString, FormattableNumber } from '@nimiq/utils';
 import { i18n } from '../../i18n/i18n-setup';
-
-export interface EtherSpecifics {
-    gasLimit?: number | string;
-    gasPrice?: string;
-    recipient?: string;
-}
 
 export type ParsedEtherSpecifics = Pick<EtherSpecifics, 'recipient'> & {
     gasLimit?: number;
     gasPrice?: bigInt.BigInteger;
 };
-
-export type EtherDirectPaymentOptions = PaymentOptions<Currency.ETH, PaymentType.DIRECT>;
 
 export class ParsedEtherDirectPaymentOptions extends ParsedPaymentOptions<Currency.ETH, PaymentType.DIRECT> {
     public amount: bigInt.BigInteger;

--- a/src/lib/paymentOptions/NimiqPaymentOptions.ts
+++ b/src/lib/paymentOptions/NimiqPaymentOptions.ts
@@ -1,19 +1,8 @@
 import { TX_VALIDITY_WINDOW, TX_MIN_VALIDITY_DURATION } from '../Constants';
-import { Currency, PaymentType, PaymentOptions } from '../PublicRequestTypes';
+import { NimiqSpecifics, NimiqDirectPaymentOptions } from '../../../client/PublicPaymentOptions';
+import { Currency, PaymentType } from '../../../client/PublicRequestTypes';
 import { ParsedPaymentOptions, PaymentOptionsParserFlags } from './ParsedPaymentOptions';
 import { toNonScientificNumberString, Utf8Tools } from '@nimiq/utils';
-
-export interface NimiqSpecifics {
-    fee?: number | string;
-    feePerByte?: number | string;
-    extraData?: Uint8Array | string;
-    validityDuration?: number;
-    flags?: number;
-    sender?: string;
-    forceSender?: boolean;
-    recipient?: string;
-    recipientType?: Nimiq.Account.Type;
-}
 
 export type ParsedNimiqSpecifics = Omit<NimiqSpecifics, 'sender' | 'recipient' | 'fee' | 'feePerByte' | 'extraData'>
     & Required<Pick<NimiqSpecifics, 'forceSender' | 'flags' | 'validityDuration'>> & {
@@ -23,8 +12,6 @@ export type ParsedNimiqSpecifics = Omit<NimiqSpecifics, 'sender' | 'recipient' |
     feePerByte?: number,
     extraData?: Uint8Array,
 };
-
-export type NimiqDirectPaymentOptions = PaymentOptions<Currency.NIM, PaymentType.DIRECT>;
 
 export class ParsedNimiqDirectPaymentOptions extends ParsedPaymentOptions<Currency.NIM, PaymentType.DIRECT> {
     public amount: number;

--- a/src/lib/paymentOptions/ParsedPaymentOptions.ts
+++ b/src/lib/paymentOptions/ParsedPaymentOptions.ts
@@ -5,7 +5,7 @@ import {
     Currency,
     PaymentType,
     PaymentOptionsForCurrencyAndType,
-} from '../PublicRequestTypes';
+} from '../../../client/PublicRequestTypes';
 import {
     ParsedPaymentOptionsForCurrencyAndType,
     ParsedProtocolSpecificsForCurrency,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Router from 'vue-router';
-import { RequestType } from '@/lib/PublicRequestTypes';
+import { RequestType } from '../client/PublicRequestTypes';
 import { KeyguardCommand } from '@nimiq/keyguard-client';
 
 const SignTransaction         = () => import(/*webpackChunkName: "sign-transaction"*/ './views/SignTransaction.vue');

--- a/src/views/ActivateBitcoinLedger.vue
+++ b/src/views/ActivateBitcoinLedger.vue
@@ -19,7 +19,7 @@ import LedgerUi from '../components/LedgerUi.vue';
 import LedgerApi from '@nimiq/ledger-api';
 import Config from 'config';
 import store from '../store';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import { BTC_ACCOUNT_KEY_PATH } from '../lib/bitcoin/BitcoinConstants';
 
 type KeyguardDeriveBtcXPubResult = import('@nimiq/keyguard-client').DeriveBtcXPubResult;

--- a/src/views/AddAccountSelection.vue
+++ b/src/views/AddAccountSelection.vue
@@ -29,7 +29,7 @@ import { State } from 'vuex-class';
 import { WalletStore } from '../lib/WalletStore';
 import { DerivedAddress } from '@nimiq/keyguard-client';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
-import { Address } from '../lib/PublicRequestTypes';
+import { Address } from '../../client/PublicRequestTypes';
 import { Static } from '../lib/StaticStore';
 
 @Component({components: {SmallPage, PageHeader, StatusScreen, GlobalClose, IdenticonSelector, CheckmarkIcon}})

--- a/src/views/AddAddressLedger.vue
+++ b/src/views/AddAddressLedger.vue
@@ -31,7 +31,7 @@ import LedgerUi from '../components/LedgerUi.vue';
 import IdenticonSelector from '../components/IdenticonSelector.vue';
 import { Static } from '../lib/StaticStore';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
-import { Address } from '../lib/PublicRequestTypes';
+import { Address } from '../../client/PublicRequestTypes';
 import { WalletInfo } from '../lib/WalletInfo';
 import { AccountInfo } from '../lib/AccountInfo';
 import LedgerApi, {

--- a/src/views/CashlinkCreate.vue
+++ b/src/views/CashlinkCreate.vue
@@ -97,7 +97,7 @@ import { State as RpcState } from '@nimiq/rpc';
 import { loadNimiq } from '../lib/Helpers';
 import { AccountInfo } from '../lib/AccountInfo';
 import { ParsedCreateCashlinkRequest } from '../lib/RequestTypes';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import { NetworkClient } from '@nimiq/network-client';
 import { WalletStore } from '../lib/WalletStore';
 import { WalletInfo } from '../lib/WalletInfo';

--- a/src/views/CashlinkManage.vue
+++ b/src/views/CashlinkManage.vue
@@ -77,7 +77,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Static } from '../lib/StaticStore';
-import { Cashlink as PublicCashlink } from '../lib/PublicRequestTypes';
+import { Cashlink as PublicCashlink } from '../../client/PublicRequestTypes';
 import { ParsedCreateCashlinkRequest, ParsedManageCashlinkRequest } from '../lib/RequestTypes';
 import {
     CloseButton,

--- a/src/views/CashlinkReceive.vue
+++ b/src/views/CashlinkReceive.vue
@@ -132,7 +132,7 @@ import StatusScreen from '../components/StatusScreen.vue';
 import CashlinkSparkle from '../components/CashlinkSparkle.vue';
 import CircleSpinner from '../components/CircleSpinner.vue';
 import Cashlink from '../lib/Cashlink';
-import { CashlinkState, BasicRequest, CashlinkTheme } from '../lib/PublicRequestTypes';
+import { CashlinkState, BasicRequest, CashlinkTheme } from '../../client/PublicRequestTypes';
 import { AccountInfo } from '../lib/AccountInfo';
 import { Getter, Mutation } from 'vuex-class';
 import { NetworkClient, DetailedPlainTransaction } from '@nimiq/network-client';

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -66,7 +66,7 @@ import CheckoutCardEthereum from '../components/CheckoutCardEthereum.vue';
 import CheckoutCardNimiq from '../components/CheckoutCardNimiq.vue';
 import CheckoutCardNimiqExternal from '../components/CheckoutCardNimiqExternal.vue';
 import GlobalClose from '../components/GlobalClose.vue';
-import { Currency as PublicCurrency } from '../lib/PublicRequestTypes';
+import { Currency as PublicCurrency } from '../../client/PublicRequestTypes';
 import { State as RpcState } from '@nimiq/rpc';
 import { Static } from '../lib/StaticStore';
 import { HISTORY_KEY_SELECTED_CURRENCY } from '../lib/Constants';

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -40,7 +40,7 @@ import { SmallPage, AccountSelector } from '@nimiq/vue-components';
 import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
 import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
-import { ChooseAddressResult, RequestType } from '../lib/PublicRequestTypes';
+import { ChooseAddressResult, RequestType } from '../../client/PublicRequestTypes';
 import { ParsedChooseAddressRequest } from '../lib/RequestTypes';
 import staticStore, { Static } from '../lib/StaticStore';
 import { WalletInfo } from '../lib/WalletInfo';

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -10,7 +10,7 @@ import {
     ParsedSignMessageRequest,
     ParsedSignTransactionRequest,
 } from '../lib/RequestTypes';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import { Errors } from '@nimiq/keyguard-client';
 import { WalletStore } from '../lib/WalletStore';
 import KeyguardClient from '@nimiq/keyguard-client';

--- a/src/views/ErrorHandlerUnsupportedLedger.vue
+++ b/src/views/ErrorHandlerUnsupportedLedger.vue
@@ -17,7 +17,7 @@ import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
 import { Static } from '../lib/StaticStore';
 import { ParsedBasicRequest } from '../lib/RequestTypes';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import { ERROR_CANCELED } from '../lib/Constants';
 
 @Component({components: {SmallPage, StatusScreen, GlobalClose}})
@@ -55,4 +55,3 @@ export default class ErrorHandlerUnsupportedLedger extends Vue {
     }
 }
 </script>
-

--- a/src/views/ExportSuccess.vue
+++ b/src/views/ExportSuccess.vue
@@ -10,7 +10,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage, CheckmarkIcon } from '@nimiq/vue-components';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
-import { ExportResult, RequestType } from '../lib/PublicRequestTypes';
+import { ExportResult, RequestType } from '../../client/PublicRequestTypes';
 import { State } from 'vuex-class';
 import staticStore, { Static } from '../lib/StaticStore';
 import StatusScreen from '../components/StatusScreen.vue';

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -20,7 +20,7 @@ import KeyguardClient from '@nimiq/keyguard-client';
 import { BrowserDetection } from '@nimiq/utils';
 import { SmallPage } from '@nimiq/vue-components';
 import { ParsedBasicRequest } from '../lib/RequestTypes';
-import { Account, RequestType } from '../lib/PublicRequestTypes';
+import { Account, RequestType } from '../../client/PublicRequestTypes';
 import { WalletInfo } from '../lib/WalletInfo';
 import { WalletStore } from '../lib/WalletStore';
 import { Static } from '../lib/StaticStore';

--- a/src/views/LogoutSuccess.vue
+++ b/src/views/LogoutSuccess.vue
@@ -9,7 +9,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
-import { SimpleResult } from '../lib/PublicRequestTypes';
+import { SimpleResult } from '../../client/PublicRequestTypes';
 import { State } from 'vuex-class';
 import { SmallPage } from '@nimiq/vue-components';
 import { WalletStore } from '@/lib/WalletStore';

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -113,7 +113,7 @@ import StatusScreen from '@/components/StatusScreen.vue';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { labelLegacyAccount } from '@/lib/LabelingMachine';
 import staticStore, { Static } from '@/lib/StaticStore';
-import { SimpleRequest, Account } from '@/lib/PublicRequestTypes';
+import { SimpleRequest, Account } from '../../client/PublicRequestTypes';
 import { State } from 'vuex-class';
 import { i18n } from '../i18n/i18n-setup';
 

--- a/src/views/OnboardingSelector.vue
+++ b/src/views/OnboardingSelector.vue
@@ -22,7 +22,7 @@ import { State as RpcState } from '@nimiq/rpc';
 import GlobalClose from '../components/GlobalClose.vue';
 import OnboardingMenu from '../components/OnboardingMenu.vue';
 import { ParsedOnboardRequest } from '@/lib/RequestTypes';
-import { RequestType } from '@/lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import { Static } from '@/lib/StaticStore';
 import { DEFAULT_KEY_PATH, ERROR_CANCELED } from '@/lib/Constants';
 import CookieHelper from '../lib/CookieHelper';

--- a/src/views/RefundSwap.vue
+++ b/src/views/RefundSwap.vue
@@ -6,7 +6,7 @@ import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
 import { BitcoinTransactionInputType } from '@nimiq/keyguard-client';
 import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import {
     ParsedRefundSwapRequest,
     ParsedSignTransactionRequest,

--- a/src/views/RefundSwapLedger.vue
+++ b/src/views/RefundSwapLedger.vue
@@ -39,7 +39,7 @@ import {
     SignBtcTransactionRequest,
     SignedTransaction,
     SignedBtcTransaction,
-} from '../lib/PublicRequestTypes';
+} from '../../client/PublicRequestTypes';
 import {
     ParsedRefundSwapRequest,
     ParsedSignTransactionRequest,

--- a/src/views/RefundSwapSuccess.vue
+++ b/src/views/RefundSwapSuccess.vue
@@ -9,7 +9,7 @@ import KeyguardClient from '@nimiq/keyguard-client';
 import { SwapAsset } from '@nimiq/fastspot-api';
 import Network from '../components/Network.vue';
 import { ParsedRefundSwapRequest } from '../lib/RequestTypes';
-import { SignedBtcTransaction, SignedTransaction } from '../lib/PublicRequestTypes';
+import { SignedBtcTransaction, SignedTransaction } from '../../client/PublicRequestTypes';
 import { Static } from '../lib/StaticStore';
 import patchMerkleTree from '../lib/MerkleTreePatch';
 

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -32,7 +32,7 @@
     import { AccountRing, AccountList, SmallPage, PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
     import Input from '../components/Input.vue';
     import { ParsedRenameRequest } from '../lib/RequestTypes';
-    import { Account } from '../lib/PublicRequestTypes';
+    import { Account } from '../../client/PublicRequestTypes';
     import StatusScreen from '../components/StatusScreen.vue';
     import GlobalClose from '../components/GlobalClose.vue';
     import { WalletInfo } from '../lib/WalletInfo';

--- a/src/views/SetupSwapLedger.vue
+++ b/src/views/SetupSwapLedger.vue
@@ -368,7 +368,7 @@ import {
 } from '@nimiq/iqons';
 import { SwapAsset } from '@nimiq/fastspot-api';
 import Config from 'config';
-import { SignedBtcTransaction } from '../lib/PublicRequestTypes';
+import { SignedBtcTransaction } from '../../client/PublicRequestTypes';
 import { WalletInfo } from '../lib/WalletInfo';
 import { ERROR_CANCELED } from '../lib/Constants';
 import { BTC_NETWORK_TEST } from '../lib/bitcoin/BitcoinConstants';

--- a/src/views/SetupSwapSuccess.vue
+++ b/src/views/SetupSwapSuccess.vue
@@ -19,7 +19,7 @@ import { init as initOasisApi, exchangeAuthorizationToken } from '@nimiq/oasis-a
 import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
 import Network from '../components/Network.vue';
-import { SetupSwapResult, SignedBtcTransaction } from '../lib/PublicRequestTypes';
+import { SetupSwapResult, SignedBtcTransaction } from '../../client/PublicRequestTypes';
 import { Static } from '../lib/StaticStore';
 import { ParsedSetupSwapRequest } from '../lib/RequestTypes';
 import Config from 'config';

--- a/src/views/SignBtcTransaction.vue
+++ b/src/views/SignBtcTransaction.vue
@@ -4,7 +4,7 @@ import { SmallPage } from '@nimiq/vue-components';
 import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
 import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import { ParsedSignBtcTransactionRequest } from '../lib/RequestTypes';
 import { Static } from '../lib/StaticStore';
 import { WalletInfo } from '../lib/WalletInfo';

--- a/src/views/SignBtcTransactionLedger.vue
+++ b/src/views/SignBtcTransactionLedger.vue
@@ -64,8 +64,8 @@ import LedgerApi, {
     TransactionInfoBitcoin as LedgerBitcoinTransactionInfo,
     RequestTypeBitcoin as LedgerApiRequestType,
 } from '@nimiq/ledger-api';
-import { RequestType } from '../lib/PublicRequestTypes';
-import { SignedBtcTransaction } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
+import { SignedBtcTransaction } from '../../client/PublicRequestTypes';
 import { ERROR_CANCELED } from '../lib/Constants';
 import { WalletInfo } from '../lib/WalletInfo';
 import { loadBitcoinJS } from '../lib/bitcoin/BitcoinJSLoader';

--- a/src/views/SignBtcTransactionSuccess.vue
+++ b/src/views/SignBtcTransactionSuccess.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { SignedBtcTransaction } from '../lib/PublicRequestTypes';
+import { SignedBtcTransaction } from '../../client/PublicRequestTypes';
 import { State } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -29,7 +29,7 @@ import { Getter, Mutation } from 'vuex-class';
 import { SmallPage, AccountSelector, ArrowRightIcon } from '@nimiq/vue-components';
 import GlobalClose from '../components/GlobalClose.vue';
 import { ParsedSignMessageRequest } from '../lib/RequestTypes';
-import { RequestType } from '../lib/PublicRequestTypes';
+import { RequestType } from '../../client/PublicRequestTypes';
 import staticStore, { Static } from '../lib/StaticStore';
 import { WalletInfo } from '@/lib/WalletInfo';
 import KeyguardClient from '@nimiq/keyguard-client';

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -10,7 +10,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { ParsedSignMessageRequest } from '../lib/RequestTypes';
-import { SignedMessage } from '../lib/PublicRequestTypes';
+import { SignedMessage } from '../../client/PublicRequestTypes';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { Static } from '@/lib/StaticStore';
 import StatusScreen from '../components/StatusScreen.vue';

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -133,7 +133,7 @@ import { Static } from '../lib/StaticStore';
 import { Getter } from 'vuex-class';
 import { State as RpcState } from '@nimiq/rpc';
 import { ParsedCreateCashlinkRequest, ParsedCheckoutRequest, ParsedSignTransactionRequest } from '../lib/RequestTypes';
-import { Currency, RequestType } from '../lib/PublicRequestTypes';
+import { Currency, RequestType } from '../../client/PublicRequestTypes';
 import { WalletInfo } from '../lib/WalletInfo';
 import { CASHLINK_FUNDING_DATA, ERROR_CANCELED, ERROR_REQUEST_TIMED_OUT, TX_VALIDITY_WINDOW } from '../lib/Constants';
 import { ParsedNimiqDirectPaymentOptions } from '../lib/paymentOptions/NimiqPaymentOptions';

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -5,7 +5,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import Network from '@/components/Network.vue';
-import { SignedTransaction } from '../lib/PublicRequestTypes';
+import { SignedTransaction } from '../../client/PublicRequestTypes';
 import { State } from 'vuex-class';
 import { Static } from '../lib/StaticStore';
 import KeyguardClient from '@nimiq/keyguard-client';

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -40,7 +40,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { AccountRing, PageBody, PageHeader, SmallPage } from '@nimiq/vue-components';
-import { Account } from '../lib/PublicRequestTypes';
+import { Account } from '../../client/PublicRequestTypes';
 import LedgerApi, {
     RequestTypeNimiq as LedgerApiRequestType,
     StateType as LedgerApiStateType,

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -14,7 +14,7 @@ import { WalletInfo } from '../lib/WalletInfo';
 import { WalletType } from '../lib/Constants';
 import { State, Action } from 'vuex-class';
 import { WalletStore } from '@/lib/WalletStore';
-import { Account } from '../lib/PublicRequestTypes';
+import { Account } from '../../client/PublicRequestTypes';
 import StatusScreen from '@/components/StatusScreen.vue';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { labelAddress, labelKeyguardAccount } from '@/lib/LabelingMachine';

--- a/src/views/SimpleSuccess.vue
+++ b/src/views/SimpleSuccess.vue
@@ -10,7 +10,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage, CheckmarkIcon } from '@nimiq/vue-components';
 import { State } from 'vuex-class';
-import { RpcRequest, SimpleResult } from '../lib/PublicRequestTypes';
+import { RpcRequest, SimpleResult } from '../../client/PublicRequestTypes';
 import { SimpleResult as KSimpleResult } from '@nimiq/keyguard-client';
 import { Static } from '@/lib/StaticStore';
 import StatusScreen from '../components/StatusScreen.vue';

--- a/tests/unit/CashlinkStore.spec.ts
+++ b/tests/unit/CashlinkStore.spec.ts
@@ -2,7 +2,7 @@ import { setup } from './_setup';
 import { Store } from '@/lib/Store';
 import { CashlinkStore } from '@/lib/CashlinkStore';
 import Cashlink from '@/lib/Cashlink';
-import { CashlinkState } from '@/lib/PublicRequestTypes';
+import { CashlinkState } from '../../client/PublicRequestTypes';
 
 setup();
 


### PR DESCRIPTION
For testing of related branches across Wallet and Hub (as is the case now for the Bitcoin integration) we want to achieve the following goals:

- Make the state of development testable outside the development environment, e.g. on testnet servers or via the branch selector
- Avoid releasing unstable NPM packages for the Keyguard and Hub clients to be used in the Hub and Wallet respectively

Linking NPM dependencies locally only works in a local dev environment.
Linking to Github branches only works when the package.json of the dependency is in the root directory of the repo (which it is not for the clients).

A promising method seems to be to use https://gitpkg.now.sh/, which can build packages of subdirectories of Github repos - This worked great for the Keyguard Client, which works independently of the rest of the Keyguard code. The Hub Client (HubApi), however, is depending on lib files from the main Hub codebase, and thus cannot be built by gitpkg.

This PR moves all public request types that are used in the Hub Client (HubApi) into the `client` folder and adjusts the references from other files linking to it. This leaves the main Hub still buildable as usual, but has the added benefit that now gitpkg can build packages for the HubApi of development branches, avoiding unstable NPM releases.