### PR TITLE
Generate UIDs for WalletInfos and return them to the Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@nimiq/browser-warning": "^1.1.0",
         "@nimiq/electrum-client": "https://github.com/nimiq/electrum-client#build",
-        "@nimiq/fastspot-api": "^1.2.1",
+        "@nimiq/fastspot-api": "^1.4.0",
         "@nimiq/iqons": "^1.5.2",
         "@nimiq/keyguard-client": "^1.4.2-beta.0",
         "@nimiq/ledger-api": "^2.1.0",

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -51,9 +51,9 @@ class IFrameApi {
             wallets = await WalletStore.Instance.list();
         }
         if (wallets.length > 0) {
-            return wallets
+            return Promise.all(wallets
                 .filter((wallet) => !wallet.keyMissing)
-                .map((wallet) => WalletInfo.objectToAccountType(wallet));
+                .map((wallet) => WalletInfo.objectToAccountType(wallet)));
         }
 
         // If no wallets exist, see if the Keyguard has keys

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -384,6 +384,7 @@ export interface Account {
         internal: string[],
         external: string[],
     };
+    uid: string;
 }
 
 export interface ExportRequest extends SimpleRequest {

--- a/src/lib/Uid.ts
+++ b/src/lib/Uid.ts
@@ -1,0 +1,41 @@
+/**
+ * The UID is used for the purpose of tracking Fastspot swap limits per user. It is generated from
+ * two deterministic values. The keyId of an account and its first NIM address, wich are always the same.
+ *
+ * The `keyId` is never passed to outside the Hub, so can be seen as a secret value. This way
+ * it is impossible for anyone who gets access to the UID alone to determine the user's address.
+ */
+export async function makeUid(keyId: string, firstAddress: string): Promise<string> {
+    return toHex(await sha256(fromAscii(`Nimiq UID: ${keyId} ${firstAddress}`)));
+}
+
+/**
+ * This method uses only browser-native APIs to avoid loading the Nimiq or Bitcoin library, as this
+ * method is also used in the iframe.
+ */
+async function sha256(buffer: Uint8Array): Promise<Uint8Array> {
+    return new Uint8Array(await window.crypto.subtle.digest('SHA-256', buffer));
+}
+
+/**
+ * Conversion functions taken from Nimiq.BufferUtils.
+ */
+
+function fromAscii(ascii: string): Uint8Array {
+    const buf = new Uint8Array(ascii.length);
+    for (let i = 0; i < ascii.length; ++i) { // tslint:disable-line:prefer-for-of
+        buf[i] = ascii.charCodeAt(i);
+    }
+    return buf;
+}
+
+function toHex(buffer: Uint8Array) {
+    const HEX_ALPHABET = '0123456789abcdef';
+    let hex = '';
+    for (let i = 0; i < buffer.length; i++) { // tslint:disable-line:prefer-for-of
+        const code = buffer[i];
+        hex += HEX_ALPHABET[code >>> 4]; // tslint:disable-line:no-bitwise
+        hex += HEX_ALPHABET[code & 0x0F]; // tslint:disable-line:no-bitwise
+    }
+    return hex;
+}

--- a/src/views/ActivateBitcoinSuccess.vue
+++ b/src/views/ActivateBitcoinSuccess.vue
@@ -63,7 +63,7 @@ export default class ActivateBitcoinSuccess extends BitcoinSyncBaseView {
 
         WalletStore.Instance.put(walletInfo);
 
-        const result = walletInfo.toAccountType();
+        const result = await walletInfo.toAccountType();
 
         this.state = this.State.FINISHED;
         setTimeout(() => { this.$rpc.resolve(result); }, StatusScreen.SUCCESS_REDIRECT_DELAY);

--- a/src/views/AddVestingContract.vue
+++ b/src/views/AddVestingContract.vue
@@ -168,8 +168,8 @@ export default class AddVestingContract extends Vue {
         setTimeout(() => this.done(), StatusScreen.SUCCESS_REDIRECT_DELAY);
     }
 
-    private done() {
-        const result = this.wallet!.toAccountType();
+    private async done() {
+        const result = await this.wallet!.toAccountType();
         this.$rpc.resolve(result);
     }
 }
@@ -246,4 +246,3 @@ export default class AddVestingContract extends Vue {
     white-space: nowrap;
 }
 </style>
-

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -171,7 +171,7 @@ export default class LoginSuccess extends Vue {
             this.$addWalletAndSetActive(walletInfo);
         }
 
-        const result: Account[] = this.walletInfos.map((walletInfo) => walletInfo.toAccountType());
+        const result: Account[] = await Promise.all(this.walletInfos.map((walletInfo) => walletInfo.toAccountType()));
 
         if (this.receiptsError) {
             this.title = this.$t('Your Addresses may be\nincomplete.') as string;

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -265,7 +265,7 @@ export default class Migrate extends Vue {
 
         this.title = this.$t('Accounts updated!') as string;
         this.state = StatusScreen.State.SUCCESS;
-        const listResult: Account[] = walletInfos.map((walletInfo) => walletInfo.toAccountType());
+        const listResult: Account[] = await Promise.all(walletInfos.map((walletInfo) => walletInfo.toAccountType()));
         setTimeout(() => this.$rpc.resolve(listResult), StatusScreen.SUCCESS_REDIRECT_DELAY);
     }
 

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -125,8 +125,8 @@
             setTimeout(() => this.done(), StatusScreen.SUCCESS_REDIRECT_DELAY);
         }
 
-        private done() {
-            const result: Account = this.wallet!.toAccountType();
+        private async done() {
+            const result: Account = await this.wallet!.toAccountType();
             this.$rpc.resolve(result);
         }
     }
@@ -189,4 +189,3 @@
         white-space: nowrap;
     }
 </style>
-

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -243,9 +243,10 @@ export default class SignupLedger extends Vue {
         // Add wallet to vuex
         this.$addWalletAndSetActive(this.walletInfo!);
 
+        const result: Account[] = [await this.walletInfo!.toAccountType()];
+
         this.state = SignupLedger.State.FINISHED;
         setTimeout(() => {
-            const result: Account[] = [this.walletInfo!.toAccountType()];
             this.$rpc.resolve(result);
         }, StatusScreen.SUCCESS_REDIRECT_DELAY);
     }

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -87,7 +87,7 @@ export default class SignupSuccess extends Vue {
         this.title = this.$t('Welcome to the\nNimiq Blockchain.') as string;
         this.state = StatusScreen.State.SUCCESS;
 
-        const result: Account[] = [walletInfo.toAccountType()];
+        const result: Account[] = [await walletInfo.toAccountType()];
         setTimeout(() => this.$rpc.resolve(result), StatusScreen.SUCCESS_REDIRECT_DELAY);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,10 +1027,10 @@
   dependencies:
     bitcoinjs-lib "^5.1.10"
 
-"@nimiq/fastspot-api@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/fastspot-api/-/fastspot-api-1.2.1.tgz#22630be7a6da7fe624e2ec85e31c9ca9e68afb22"
-  integrity sha512-p1/pYrObxNEgRqNAgkXWbDbbwfObXKXaXeFkWKG473Ywc5xTDGxVzW9FmD8+DbaSIm1WZDKi7CbYovu+JEQe+w==
+"@nimiq/fastspot-api@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/fastspot-api/-/fastspot-api-1.4.0.tgz#bfcad4eb797a3016d33dbf3d2dabe39b162494c5"
+  integrity sha512-UORkWgg0ZTLrsXCXRC3hfVWYn7EtcSRXMhzCULEc2bE4NJ/YaeCOs0UamCknEXrS8Qlb4RIUTDAVyKVnIqPMUA==
 
 "@nimiq/iqons@^1.5.2":
   version "1.5.2"


### PR DESCRIPTION
This PR adds a new field to the `Account` type returned to the Wallet: a `uid`. It is returned everywhere where an account is returned.
Iframes in iOS/Safari, which don't have the `keyId` stored in the cookie, return an empty string. The wallet falls back to tracking swap volume via transaction history when the UID is not available, but since it is returned for signups, logins, renames, exports, it will soon be available for those users also.

Generating the UID is a runtime SHA256 hash, which is super fast and not noticeable until ~100 accounts per browser.

> The UID is used for the purpose of tracking Fastspot swap limits per user. It is generated from two deterministic values. The keyId of an account and its first NIM address, wich are always the same.
>
> The `keyId` is never passed to outside the Hub, so can be seen as a secret value. This way it is impossible for anyone who gets access to the UID alone to determine the user's address.