### PR TITLE
Allow getting BTC address for an account when requesting a NIM address

### DIFF
--- a/client/HubApi.ts
+++ b/client/HubApi.ts
@@ -11,6 +11,8 @@ import {
     BasicRequest,
     SimpleRequest,
     OnboardRequest,
+    ChooseAddressRequest,
+    ChooseAddressResult,
     CheckoutRequest,
     SignTransactionRequest,
     RenameRequest,
@@ -144,9 +146,9 @@ export default class HubApi<DB extends BehaviorType = BehaviorType.POPUP> { // D
     }
 
     public chooseAddress<B extends BehaviorType = DB>(
-        request: Promise<BasicRequest> | BasicRequest,
+        request: Promise<ChooseAddressRequest> | ChooseAddressRequest,
         requestBehavior: RequestBehavior<B> = this._defaultBehavior as any,
-    ): Promise<B extends BehaviorType.REDIRECT ? void : Address> {
+    ): Promise<B extends BehaviorType.REDIRECT ? void : ChooseAddressResult> {
         return this._request(requestBehavior, RequestType.CHOOSE_ADDRESS, [request]);
     }
 

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -168,7 +168,18 @@ class Demo {
             try {
                 const result = await demo.client.chooseAddress({ appName: 'Hub Demos' }, demo._defaultBehavior);
                 console.log('Result', result);
-                document.querySelector('#result').textContent = 'Address was chosen';
+                document.querySelector('#result').textContent = `Address was chosen: ${result ? result.address : '-'}`;
+            } catch (e) {
+                console.error(e);
+                document.querySelector('#result').textContent = `Error: ${e.message || e}`;
+            }
+        });
+
+        document.querySelector('button#choose-address-and-btc').addEventListener('click', async () => {
+            try {
+                const result = await demo.client.chooseAddress({ appName: 'Hub Demos', returnBtcAddress: true }, demo._defaultBehavior);
+                console.log('Result', result);
+                document.querySelector('#result').textContent = `Address was chosen: ${result ? result.address : '-'}`;
             } catch (e) {
                 console.error(e);
                 document.querySelector('#result').textContent = `Error: ${e.message || e}`;

--- a/demos/index.html
+++ b/demos/index.html
@@ -53,6 +53,7 @@
 
     <h2>Choose Address</h2>
     <button id="choose-address" disabled>Choose address</button>
+    <button id="choose-address-and-btc" disabled>Choose address + BTC</button>
 </div>
 
 <div class="request">

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -49,6 +49,19 @@ export interface OnboardRequest extends BasicRequest {
     disableBack?: boolean;
 }
 
+export interface ChooseAddressRequest extends BasicRequest {
+    returnBtcAddress?: boolean;
+    minBalance?: number;
+    disableContracts?: boolean;
+    disableLegacyAddresses?: boolean;
+    disableBip39Addresses?: boolean;
+    disableLedgerAddresses?: boolean;
+}
+
+export interface ChooseAddressResult extends Address {
+    btcAddress?: string;
+}
+
 export interface SignTransactionRequest extends BasicRequest {
     sender: string;
     recipient: string;
@@ -500,6 +513,7 @@ export type RpcRequest = SignTransactionRequest
                        | CheckoutRequest
                        | BasicRequest
                        | SimpleRequest
+                       | ChooseAddressRequest
                        | OnboardRequest
                        | RenameRequest
                        | SignMessageRequest
@@ -513,6 +527,7 @@ export type RpcResult = SignedTransaction
                       | Account
                       | Account[]
                       | SimpleResult
+                      | ChooseAddressResult
                       | Address
                       | Cashlink
                       | Cashlink[]

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -53,9 +53,9 @@ export interface ChooseAddressRequest extends BasicRequest {
     returnBtcAddress?: boolean;
     minBalance?: number;
     disableContracts?: boolean;
-    disableLegacyAddresses?: boolean;
-    disableBip39Addresses?: boolean;
-    disableLedgerAddresses?: boolean;
+    disableLegacyAccounts?: boolean;
+    disableBip39Accounts?: boolean;
+    disableLedgerAccounts?: boolean;
 }
 
 export interface ChooseAddressResult extends Address {

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -260,12 +260,12 @@ export class RequestParser {
                 return {
                     kind: requestType,
                     appName: chooseAddressRequest.appName,
-                    returnBtcAddress: chooseAddressRequest.returnBtcAddress || false,
-                    minBalance: chooseAddressRequest.minBalance || 0,
-                    disableContracts: chooseAddressRequest.disableContracts || false,
-                    disableLegacyAddresses: chooseAddressRequest.disableLegacyAddresses || false,
-                    disableBip39Addresses: chooseAddressRequest.disableBip39Addresses || false,
-                    disableLedgerAddresses: chooseAddressRequest.disableLedgerAddresses || false,
+                    returnBtcAddress: !!chooseAddressRequest.returnBtcAddress,
+                    minBalance: Number(chooseAddressRequest.minBalance) || 0,
+                    disableContracts: !!chooseAddressRequest.disableContracts,
+                    disableLegacyAddresses: !!chooseAddressRequest.disableLegacyAddresses,
+                    disableBip39Addresses: !!chooseAddressRequest.disableBip39Addresses,
+                    disableLedgerAddresses: !!chooseAddressRequest.disableLedgerAddresses,
                 } as ParsedChooseAddressRequest;
             case RequestType.SIGNUP:
             case RequestType.LOGIN:

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -263,9 +263,9 @@ export class RequestParser {
                     returnBtcAddress: !!chooseAddressRequest.returnBtcAddress,
                     minBalance: Number(chooseAddressRequest.minBalance) || 0,
                     disableContracts: !!chooseAddressRequest.disableContracts,
-                    disableLegacyAddresses: !!chooseAddressRequest.disableLegacyAddresses,
-                    disableBip39Addresses: !!chooseAddressRequest.disableBip39Addresses,
-                    disableLedgerAddresses: !!chooseAddressRequest.disableLedgerAddresses,
+                    disableLegacyAccounts: !!chooseAddressRequest.disableLegacyAccounts,
+                    disableBip39Accounts: !!chooseAddressRequest.disableBip39Accounts,
+                    disableLedgerAccounts: !!chooseAddressRequest.disableLedgerAccounts,
                 } as ParsedChooseAddressRequest;
             case RequestType.SIGNUP:
             case RequestType.LOGIN:

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -8,6 +8,7 @@ import {
     ExportRequest,
     ManageCashlinkRequest,
     OnboardRequest,
+    ChooseAddressRequest,
     RenameRequest,
     RpcRequest,
     SignMessageRequest,
@@ -29,6 +30,7 @@ import {
     ParsedExportRequest,
     ParsedManageCashlinkRequest,
     ParsedOnboardRequest,
+    ParsedChooseAddressRequest,
     ParsedRenameRequest,
     ParsedRpcRequest,
     ParsedSignMessageRequest,
@@ -253,8 +255,19 @@ export class RequestParser {
                     appName: onboardRequest.appName,
                     disableBack: !!onboardRequest.disableBack,
                 } as ParsedOnboardRequest;
-            case RequestType.SIGNUP:
             case RequestType.CHOOSE_ADDRESS:
+                const chooseAddressRequest = request as ChooseAddressRequest;
+                return {
+                    kind: requestType,
+                    appName: chooseAddressRequest.appName,
+                    returnBtcAddress: chooseAddressRequest.returnBtcAddress || false,
+                    minBalance: chooseAddressRequest.minBalance || 0,
+                    disableContracts: chooseAddressRequest.disableContracts || false,
+                    disableLegacyAddresses: chooseAddressRequest.disableLegacyAddresses || false,
+                    disableBip39Addresses: chooseAddressRequest.disableBip39Addresses || false,
+                    disableLedgerAddresses: chooseAddressRequest.disableLedgerAddresses || false,
+                } as ParsedChooseAddressRequest;
+            case RequestType.SIGNUP:
             case RequestType.LOGIN:
             case RequestType.MIGRATE:
             case RequestType.ADD_VESTING_CONTRACT:
@@ -680,8 +693,12 @@ export class RequestParser {
                     appName: onboardRequest.appName,
                     disableBack: onboardRequest.disableBack,
                 } as OnboardRequest;
-            case RequestType.SIGNUP:
             case RequestType.CHOOSE_ADDRESS:
+                const chooseAddressRequest = request as ParsedChooseAddressRequest;
+                return {
+                    ...chooseAddressRequest,
+                } as ChooseAddressRequest;
+            case RequestType.SIGNUP:
             case RequestType.LOGIN:
             case RequestType.MIGRATE:
             case RequestType.ADD_VESTING_CONTRACT:

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -22,9 +22,9 @@ export interface ParsedChooseAddressRequest extends ParsedBasicRequest {
     returnBtcAddress: boolean;
     minBalance: number;
     disableContracts: boolean;
-    disableLegacyAddresses: boolean;
-    disableBip39Addresses: boolean;
-    disableLedgerAddresses: boolean;
+    disableLegacyAccounts: boolean;
+    disableBip39Accounts: boolean;
+    disableLedgerAccounts: boolean;
 }
 
 export interface ParsedSignTransactionRequest extends ParsedBasicRequest {

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -18,6 +18,15 @@ export interface ParsedOnboardRequest extends ParsedBasicRequest {
     disableBack: boolean;
 }
 
+export interface ParsedChooseAddressRequest extends ParsedBasicRequest {
+    returnBtcAddress: boolean;
+    minBalance: number;
+    disableContracts: boolean;
+    disableLegacyAddresses: boolean;
+    disableBip39Addresses: boolean;
+    disableLedgerAddresses: boolean;
+}
+
 export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     // The sender object is currently only for internal use in RefundSwapLedger and can not be set in public request.
     // Note that the object does not get exported to the history state in RpcApi and therefore does not survive reloads.

--- a/src/views/AddAccountSelection.vue
+++ b/src/views/AddAccountSelection.vue
@@ -21,6 +21,8 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage, PageHeader, CheckmarkIcon } from '@nimiq/vue-components';
+import StatusScreen from '../components/StatusScreen.vue';
+import GlobalClose from '../components/GlobalClose.vue';
 import IdenticonSelector from '../components/IdenticonSelector.vue';
 import { AccountInfo } from '../lib/AccountInfo';
 import { State } from 'vuex-class';
@@ -28,8 +30,6 @@ import { WalletStore } from '../lib/WalletStore';
 import { DerivedAddress } from '@nimiq/keyguard-client';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
 import { Address } from '../lib/PublicRequestTypes';
-import StatusScreen from '../components/StatusScreen.vue';
-import GlobalClose from '../components/GlobalClose.vue';
 import { Static } from '../lib/StaticStore';
 
 @Component({components: {SmallPage, PageHeader, StatusScreen, GlobalClose, IdenticonSelector, CheckmarkIcon}})

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -11,9 +11,9 @@
                 :wallets="processedWallets"
                 :minBalance="request.minBalance"
                 :disableContracts="request.disableContracts"
-                :disableLegacyAccounts="request.disableLegacyAddresses"
-                :disableBip39Accounts="request.disableBip39Addresses"
-                :disableLedgerAccounts="request.disableLedgerAddresses"
+                :disableLegacyAccounts="request.disableLegacyAccounts"
+                :disableBip39Accounts="request.disableBip39Accounts"
+                :disableLedgerAccounts="request.disableLedgerAccounts"
                 :highlightBitcoinAccounts="request.returnBtcAddress"
                 @account-selected="accountSelected"
                 @login="() => goToOnboarding(false)"/>

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -18,7 +18,7 @@
                 @account-selected="accountSelected"
                 @login="() => goToOnboarding(false)"/>
 
-            <StatusScreen v-if="state !== 'none'"
+            <StatusScreen v-if="state !== State.NONE"
                 :state="statusScreenState"
                 :title="statusScreenTitle"
                 :status="statusScreenStatus"
@@ -37,18 +37,18 @@
 import { Component } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { SmallPage, AccountSelector } from '@nimiq/vue-components';
+import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
+import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
 import { ChooseAddressResult, RequestType } from '../lib/PublicRequestTypes';
 import { ParsedChooseAddressRequest } from '../lib/RequestTypes';
-import staticStore, { Static } from '@/lib/StaticStore';
+import staticStore, { Static } from '../lib/StaticStore';
 import { WalletInfo } from '../lib/WalletInfo';
 import { AccountInfo } from '../lib/AccountInfo';
 import { ContractInfo } from '../lib/ContractInfo';
 import WalletInfoCollector from '../lib/WalletInfoCollector';
 import { WalletStore } from '../lib/WalletStore';
-import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
 import { BtcAddressInfo } from '../lib/bitcoin/BtcAddressInfo';
-import StatusScreen from '../components/StatusScreen.vue';
 
 @Component({components: { AccountSelector, SmallPage, StatusScreen, GlobalClose }})
 export default class ChooseAddress extends BitcoinSyncBaseView {
@@ -103,12 +103,12 @@ export default class ChooseAddress extends BitcoinSyncBaseView {
                 return;
             }
             walletInfo.btcAddresses = btcAddresses;
-            WalletStore.Instance.put(walletInfo);
+            await WalletStore.Instance.put(walletInfo);
             const unusedExternalAddresses = btcAddresses.external.filter((addressInfo) => !addressInfo.used);
             if (unusedExternalAddresses.length > 0) {
                 // We try to use the 7th unused address, because the first is reserved for swaps, and the next 5
                 // are reserved for copying in the Wallet. This way we hope to not have double-use of an address.
-                btcAddress = unusedExternalAddresses[Math.min(unusedExternalAddresses.length, 6)].address;
+                btcAddress = unusedExternalAddresses[Math.min(unusedExternalAddresses.length - 1, 6)].address;
             }
         }
 

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -9,9 +9,24 @@
 
             <AccountSelector
                 :wallets="processedWallets"
+                :minBalance="request.minBalance"
+                :disableContracts="request.disableContracts"
+                :disableLegacyAccounts="request.disableLegacyAddresses"
+                :disableBip39Accounts="request.disableBip39Addresses"
+                :disableLedgerAccounts="request.disableLedgerAddresses"
+                :highlightBitcoinAccounts="request.returnBtcAddress"
                 @account-selected="accountSelected"
                 @login="() => goToOnboarding(false)"/>
 
+            <StatusScreen v-if="state !== 'none'"
+                :state="statusScreenState"
+                :title="statusScreenTitle"
+                :status="statusScreenStatus"
+                :message="statusScreenMessage"
+                :mainAction="statusScreenAction"
+                :lightBlue="!useDarkSyncStatusScreen"
+                @main-action="_statusScreenActionHandler"
+            />
         </SmallPage>
 
         <GlobalClose />
@@ -19,19 +34,25 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { SmallPage, AccountSelector } from '@nimiq/vue-components';
 import GlobalClose from '../components/GlobalClose.vue';
-import { SimpleRequest, Address, RequestType } from '../lib/PublicRequestTypes';
+import { ChooseAddressResult, RequestType } from '../lib/PublicRequestTypes';
+import { ParsedChooseAddressRequest } from '../lib/RequestTypes';
 import staticStore, { Static } from '@/lib/StaticStore';
 import { WalletInfo } from '../lib/WalletInfo';
 import { AccountInfo } from '../lib/AccountInfo';
 import { ContractInfo } from '../lib/ContractInfo';
+import WalletInfoCollector from '../lib/WalletInfoCollector';
+import { WalletStore } from '../lib/WalletStore';
+import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
+import { BtcAddressInfo } from '../lib/bitcoin/BtcAddressInfo';
+import StatusScreen from '../components/StatusScreen.vue';
 
-@Component({components: { AccountSelector, SmallPage, GlobalClose }})
-export default class ChooseAddress extends Vue {
-    @Static private request!: SimpleRequest;
+@Component({components: { AccountSelector, SmallPage, StatusScreen, GlobalClose }})
+export default class ChooseAddress extends BitcoinSyncBaseView {
+    @Static private request!: ParsedChooseAddressRequest;
 
     @Getter private findWallet!: (id: string) => WalletInfo | undefined;
     @Getter private processedWallets!: WalletInfo[];
@@ -47,7 +68,7 @@ export default class ChooseAddress extends Vue {
         }
     }
 
-    private accountSelected(walletId: string, address: string) {
+    private async accountSelected(walletId: string, address: string) {
         const walletInfo = this.findWallet(walletId);
         if (!walletInfo) {
             console.error('UNEXPECTED: Selected walletId not found:', walletId);
@@ -62,9 +83,39 @@ export default class ChooseAddress extends Vue {
             userFriendlyAddress: accountOrContractInfo.userFriendlyAddress,
         });
 
-        const result: Address = {
+        let btcAddress: string | undefined;
+
+        if (this.request.returnBtcAddress && walletInfo.btcXPub) {
+            this.state = this.State.SYNCING;
+            // const startIndex = Math.max(Math.min(
+            //     walletInfo.btcAddresses.external.findIndex((addressInfo) => !addressInfo.used),
+            //     walletInfo.btcAddresses.internal.findIndex((addressInfo) => !addressInfo.used),
+            // ), 0);
+            let btcAddresses: {
+                internal: BtcAddressInfo[];
+                external: BtcAddressInfo[];
+            };
+            try {
+                btcAddresses = await WalletInfoCollector.detectBitcoinAddresses(walletInfo.btcXPub, /* startIndex */ 0);
+            } catch (error) {
+                this.state = this.State.SYNCING_FAILED;
+                this.error = error.message;
+                return;
+            }
+            walletInfo.btcAddresses = btcAddresses;
+            WalletStore.Instance.put(walletInfo);
+            const unusedExternalAddresses = btcAddresses.external.filter((addressInfo) => !addressInfo.used);
+            if (unusedExternalAddresses.length > 0) {
+                // We try to use the 7th unused address, because the first is reserved for swaps, and the next 5
+                // are reserved for copying in the Wallet. This way we hope to not have double-use of an address.
+                btcAddress = unusedExternalAddresses[Math.min(unusedExternalAddresses.length, 6)].address;
+            }
+        }
+
+        const result: ChooseAddressResult = {
             address: accountOrContractInfo.userFriendlyAddress,
             label: accountOrContractInfo.label,
+            btcAddress,
         };
 
         this.$rpc.resolve(result);
@@ -98,5 +149,13 @@ export default class ChooseAddress extends Vue {
         margin-left: 2rem;
         margin-right: 2rem;
         flex-shrink: 0;
+    }
+
+    .status-screen {
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
     }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1124,7 +1124,7 @@
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components#build/hub":
   version "0.1.0"
-  resolved "https://github.com/nimiq/vue-components#86dc70efb2dda4f5ab242ea1d1069d4ba1b650a2"
+  resolved "https://github.com/nimiq/vue-components#b0ecfe4769a81c078cf60bcded560a026fee6c39"
   dependencies:
     "@nimiq/style" "^0.8.2"
     big-integer "^1.6.44"


### PR DESCRIPTION
Allow the `ChooseAddress` request to also request a BTC address for the account of which the NIM address was selected. It does not enforce selecting an account that supports BTC, so the `btcAddress` in the result can still be `undefined`. I have additionally updated the `AccountSelector` component in vue-components a bit to display a "BTC" label next to BTC-enabled account labels, if a BTC address is expected in the result.

Additionally, I have made all filtering `AccountSelector` props available as request options, to filter the list of selectable addresses (which makes sense in the CPL case, where contract addresses should not be able to be selected, as they cannot receive NIM).