### PR TITLE
Add SRI

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "typescript": "~3.8.0",
         "vue-template-compiler": "^2.6.11",
         "webpack-i18n-tools": "https://github.com/nimiq/webpack-i18n-tools#master",
+        "webpack-subresource-integrity": "^1.5.2",
         "write-file-webpack-plugin": "^4.5.1"
     }
 }

--- a/public/cashlink.html
+++ b/public/cashlink.html
@@ -5,8 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <!-- Use no custom browser warning share behavior here as cashlink can be opened just fine in other browser. -->
-    <script type="text/javascript" src="/browser-warning.js" defer></script>
-    <script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
+    <script defer type="text/javascript" src="/browser-warning.js"
+        integrity="sha384-uD+5DCOecWr/q7O6o3+wSmLISre1e1jU4Fb8T9cepmOMYcMRMSBBgyNXWGdoG1aE"
+        crossorigin="anonymous"></script>
+    <script defer src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js"
+        integrity="sha384-E/6QJnv+vWgA4ZFJTmZcbN0x/Zo715x+nQscANpRmkcZWje5w6gCkDaWrqX0HWF8"
+        crossorigin="anonymous"></script>
     <title>Nimiq Cashlink</title>
 
     <meta name="robots" content="noindex, follow">

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,12 @@
     doesn't make sense because the hub requires a request. Note that the snippet is written in old-fashioned Javascript
     as required by the browser warnings and minified by hand as the HtmlWebpackPlugin only minifies html. -->
     <script>window.onBrowserWarning=function(){var caller=document.referrer||window.opener;return{hasShareButton:caller,shareUrl:caller}}</script>
-    <script type="text/javascript" src="/browser-warning.js" defer></script>
-    <script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
+    <script defer type="text/javascript" src="/browser-warning.js"
+        integrity="sha384-uD+5DCOecWr/q7O6o3+wSmLISre1e1jU4Fb8T9cepmOMYcMRMSBBgyNXWGdoG1aE"
+        crossorigin="anonymous"></script>
+    <script defer src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js"
+        integrity="sha384-E/6QJnv+vWgA4ZFJTmZcbN0x/Zo715x+nQscANpRmkcZWje5w6gCkDaWrqX0HWF8"
+        crossorigin="anonymous"></script>
     <title>Nimiq</title>
     <meta name="robots" content="noindex">
     <meta name="description" content="Nimiq Hub provides a unified interface for all Nimiq accounts, addresses, and contracts.">

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,5 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const SriPlugin = require('webpack-subresource-integrity');
 const WriteFileWebpackPlugin = require('write-file-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const path = require('path');
@@ -27,6 +28,10 @@ console.log('Building for:', buildName);
 
 const configureWebpack = {
     plugins: [
+        new SriPlugin({
+            hashFuncNames: ['sha384'],
+            enabled: process.env.NODE_ENV === 'production',
+        }),
         new CopyWebpackPlugin([
             { from: 'node_modules/@nimiq/browser-warning/dist', to: './' },
             {
@@ -59,6 +64,7 @@ const configureWebpack = {
     // TODO: 'eval-source-map' temporarily removed for webpack-i18n-tools, will be fixed in future versions
     node: false,
     output: {
+        crossOriginLoading: 'anonymous',
         devtoolModuleFilenameTemplate: info => {
             let $filename = 'sources://' + info.resourcePath;
             if (info.resourcePath.match(/\.vue$/) && !info.query.match(/type=script/)) {
@@ -141,6 +147,7 @@ if (buildName === 'local' || buildName === 'testnet') {
 
 module.exports = {
     pages,
+    integrity: true,
     configureWebpack,
     chainWebpack: config => {
         // Do not put prefetch/preload links into the landing pages

--- a/yarn.lock
+++ b/yarn.lock
@@ -11325,13 +11325,20 @@ webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-subresource-integrity@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/webpack-subresource-integrity/-/webpack-subresource-integrity-1.5.2.tgz#e40b6578d3072e2d24104975249c52c66e9a743e"
+  integrity sha512-GBWYBoyalbo5YClwWop9qe6Zclp8CIXYGIz12OPclJhIrSplDxs1Ls1JDMH8xBPPrg1T6ISaTW9Y6zOrwEiAzw==
+  dependencies:
+    webpack-sources "^1.3.0"
 
 webpack@^4.0.0:
   version "4.41.6"


### PR DESCRIPTION
Let Vue.js automatically add SRI to all script tags it produces.
There are two scripts in the `index.html` that still require the SRI to be manually set:
`browser-warning.js` and the Core JS library.

What would be the best way to set these? Should it be hardcoded into the html or somehow be part of the build process?