### PR TITLE
Minor fixes for Checkout

### DIFF
--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -352,6 +352,10 @@ export default Checkout;
             --ios-bottom-bar-height: 74px;
         }
 
+        .carousel.ios >>> .currency-info {
+            --currency-info-translate-y: -50px;
+        }
+
         .carousel >>> .confirmed .nq-card {
             height: var(--available-mobile-height);
         }

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -149,7 +149,9 @@ class Checkout extends Vue {
     }
 
     private mounted() {
-        const disclaimer = (this.$refs.disclaimer as BottomOverlay).$el || this.$refs.disclaimer;
+        const disclaimer = this.$refs.disclaimer
+            ? (this.$refs.disclaimer as BottomOverlay).$el || this.$refs.disclaimer
+            : undefined;
         this.hasLongDisclaimer = !!disclaimer && disclaimer.textContent!.length > 250;
     }
 


### PR DESCRIPTION
This PR contain 2 minor fixes:
- Added a null check for `this.$refs.disclaimer` in `mounted`hook to prevent "undefined is not an object" error.
- Fix .currency-info alignment for IOS, so that the text is not cut out and the fees are visible.