### PR TITLE
Auto generate integrity hashes for core, browser warnings and BitcoinJS

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -164,7 +164,10 @@
 </div>
 
 <!-- needed for Sign Btc Transaction demo -->
-<script src="/bitcoin/BitcoinJS.min.js"></script>
+<script defer type="text/javascript"
+    src="/bitcoin/BitcoinJS.min.js"
+    integrity="<%= htmlWebpackPlugin.options.bitcoinJsIntegrityHash %>"
+    crossorigin="anonymous"></script>
 <!-- needed for WalletStore in Activate Btc demo -->
 <script defer type="text/javascript"
     src="<%= htmlWebpackPlugin.options.cdnDomain %>/v<%= htmlWebpackPlugin.options.coreVersion %>/web-offline.js"

--- a/demos/index.html
+++ b/demos/index.html
@@ -166,7 +166,10 @@
 <!-- needed for Sign Btc Transaction demo -->
 <script src="/bitcoin/BitcoinJS.min.js"></script>
 <!-- needed for WalletStore in Activate Btc demo -->
-<script src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js" defer></script>
+<script defer type="text/javascript"
+    src="<%= htmlWebpackPlugin.options.cdnDomain %>/v<%= htmlWebpackPlugin.options.coreVersion %>/web-offline.js"
+    integrity="<%= htmlWebpackPlugin.options.coreIntegrityHash %>"
+    crossorigin="anonymous"></script>
 
 <!-- built files will be auto injected -->
 </body>

--- a/public/cashlink.html
+++ b/public/cashlink.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <!-- Use no custom browser warning share behavior here as cashlink can be opened just fine in other browser. -->
     <script defer type="text/javascript" src="/browser-warning.js"
-        integrity="sha384-uD+5DCOecWr/q7O6o3+wSmLISre1e1jU4Fb8T9cepmOMYcMRMSBBgyNXWGdoG1aE"
+        integrity="<%= htmlWebpackPlugin.options.browserWarningIntegrityHash %>"
         crossorigin="anonymous"></script>
-    <script defer src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js"
-        integrity="sha384-E/6QJnv+vWgA4ZFJTmZcbN0x/Zo715x+nQscANpRmkcZWje5w6gCkDaWrqX0HWF8"
+    <script defer src="<%= htmlWebpackPlugin.options.cdnDomain %>/v<%= htmlWebpackPlugin.options.coreVersion %>/web-offline.js"
+        integrity="<%= htmlWebpackPlugin.options.coreIntegrityHash %>"
         crossorigin="anonymous"></script>
     <title>Nimiq Cashlink</title>
 
@@ -40,7 +40,7 @@
             </g></svg>
         </div>
     </div>
-    <%= htmlWebpackPlugin.options.browserWarning %>
+    <%= htmlWebpackPlugin.options.browserWarningTemplate %>
     <!-- built files will be auto injected -->
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -10,10 +10,10 @@
     as required by the browser warnings and minified by hand as the HtmlWebpackPlugin only minifies html. -->
     <script>window.onBrowserWarning=function(){var caller=document.referrer||window.opener;return{hasShareButton:caller,shareUrl:caller}}</script>
     <script defer type="text/javascript" src="/browser-warning.js"
-        integrity="sha384-uD+5DCOecWr/q7O6o3+wSmLISre1e1jU4Fb8T9cepmOMYcMRMSBBgyNXWGdoG1aE"
+        integrity="<%= htmlWebpackPlugin.options.browserWarningIntegrityHash %>"
         crossorigin="anonymous"></script>
-    <script defer src="<%= htmlWebpackPlugin.options.cdnDomain %>/v1.5.3/web-offline.js"
-        integrity="sha384-E/6QJnv+vWgA4ZFJTmZcbN0x/Zo715x+nQscANpRmkcZWje5w6gCkDaWrqX0HWF8"
+    <script defer src="<%= htmlWebpackPlugin.options.cdnDomain %>/v<%= htmlWebpackPlugin.options.coreVersion %>/web-offline.js"
+        integrity="<%= htmlWebpackPlugin.options.coreIntegrityHash %>"
         crossorigin="anonymous"></script>
     <title>Nimiq</title>
     <meta name="robots" content="noindex">
@@ -38,7 +38,7 @@
             </g></svg>
         </div>
     </div>
-    <%= htmlWebpackPlugin.options.browserWarning %>
+    <%= htmlWebpackPlugin.options.browserWarningTemplate %>
     <!-- built files will be auto injected -->
 </body>
 

--- a/src/lib/bitcoin/BitcoinJSLoader.ts
+++ b/src/lib/bitcoin/BitcoinJSLoader.ts
@@ -12,6 +12,8 @@ export async function loadBitcoinJS(): Promise<boolean> {
                 resolve(true);
             });
             script.addEventListener('error', reject);
+            script.integrity = process.env.VUE_APP_BITCOIN_JS_INTEGRITY_HASH!; // defined in vue.config.js
+            script.crossOrigin = 'anonymous';
             script.src = '/bitcoin/BitcoinJS.min.js';
             document.body.appendChild(script);
         })

--- a/vue.config.js
+++ b/vue.config.js
@@ -51,7 +51,11 @@ const configureWebpack = {
             enabled: process.env.NODE_ENV === 'production',
         }),
         new CopyWebpackPlugin([
-            { from: 'node_modules/@nimiq/browser-warning/dist', to: './' },
+            {
+                from: 'node_modules/@nimiq/browser-warning/dist/browser-warning.js*',
+                to: './',
+                flatten: true,
+            },
             {
                 from: 'node_modules/@nimiq/vue-components/dist/iqons.min.*.svg',
                 to: './img/',

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,9 +4,10 @@ const WriteFileWebpackPlugin = require('write-file-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const path = require('path');
 const fs = require('fs');
-const browserWarning = fs.readFileSync(__dirname + '/node_modules/@nimiq/browser-warning/dist/browser-warning.html.template');
+const createHash = require('crypto').createHash;
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const PoLoaderOptimizer = require('webpack-i18n-tools')();
+const coreVersion = require('@nimiq/core-web/package.json').version;
 
 const buildName = process.env.NODE_ENV === 'production'
     ? process.env.build
@@ -14,15 +15,25 @@ const buildName = process.env.NODE_ENV === 'production'
 
 if (!buildName) throw new Error('Please specify the build config with the `build` environment variable');
 
-const cdnDomain = buildName === 'mainnet'
-    ? 'https://cdn.nimiq.com'
-    : 'https://cdn.nimiq-testnet.com';
-
 const domain = buildName === 'mainnet'
     ? 'https://hub.nimiq.com'
     : buildName === 'testnet'
         ? 'https://hub.nimiq-testnet.com'
         : 'http://localhost:8080';
+
+const cdnDomain = buildName === 'mainnet'
+    ? 'https://cdn.nimiq.com'
+    : 'https://cdn.nimiq-testnet.com';
+
+const browserWarningTemplate = fs.readFileSync(
+    path.join(__dirname, 'node_modules/@nimiq/browser-warning/dist/browser-warning.html.template'));
+
+const browserWarningIntegrityHash = `sha384-${createHash('sha384')
+    .update(fs.readFileSync(path.join(__dirname, 'node_modules/@nimiq/browser-warning/dist/browser-warning.js')))
+    .digest('base64')}`;
+const coreIntegrityHash = `sha384-${createHash('sha384')
+    .update(fs.readFileSync(path.join(__dirname, 'node_modules/@nimiq/core-web/web-offline.js')))
+    .digest('base64')}`;
 
 console.log('Building for:', buildName);
 
@@ -86,10 +97,13 @@ const pages = {
         entry: 'src/main.ts',
         // the source template
         template: 'public/index.html',
-        // insert browser warning html templates
-        browserWarning,
-        cdnDomain,
+        // insert browser warning html template
+        browserWarningTemplate,
+        browserWarningIntegrityHash,
         domain,
+        cdnDomain,
+        coreVersion,
+        coreIntegrityHash,
         // output as dist/index.html
         filename: 'index.html',
         // chunks to include on this page, by default includes
@@ -112,10 +126,13 @@ const pages = {
         entry: 'src/cashlink.ts',
         // the source template
         template: 'public/cashlink.html',
-        // insert browser warning html templates
-        browserWarning,
-        cdnDomain,
+        // insert browser warning html template
+        browserWarningTemplate,
+        browserWarningIntegrityHash,
         domain,
+        cdnDomain,
+        coreVersion,
+        coreIntegrityHash,
         // output as dist/cashlink/index.html
         filename: 'cashlink/index.html',
         // chunks to include on this page, by default includes
@@ -131,6 +148,8 @@ if (buildName === 'local' || buildName === 'testnet') {
         // the source template
         template: 'demos/index.html',
         cdnDomain,
+        coreVersion,
+        coreIntegrityHash,
         // output as dist/demos.html
         filename: 'demos.html',
         // chunks to include on this page, by default includes

--- a/vue.config.js
+++ b/vue.config.js
@@ -34,6 +34,13 @@ const browserWarningIntegrityHash = `sha384-${createHash('sha384')
 const coreIntegrityHash = `sha384-${createHash('sha384')
     .update(fs.readFileSync(path.join(__dirname, 'node_modules/@nimiq/core-web/web-offline.js')))
     .digest('base64')}`;
+const bitcoinJsIntegrityHash = `sha384-${createHash('sha384')
+    .update(fs.readFileSync(path.join(__dirname, 'public/bitcoin/BitcoinJS.min.js')))
+    .digest('base64')}`;
+
+// Accesible within client code via process.env.VUE_APP_BITCOIN_JS_INTEGRITY_HASH,
+// see https://cli.vuejs.org/guide/mode-and-env.html#using-env-variables-in-client-side-code
+process.env.VUE_APP_BITCOIN_JS_INTEGRITY_HASH = bitcoinJsIntegrityHash;
 
 console.log('Building for:', buildName);
 
@@ -150,6 +157,7 @@ if (buildName === 'local' || buildName === 'testnet') {
         cdnDomain,
         coreVersion,
         coreIntegrityHash,
+        bitcoinJsIntegrityHash,
         // output as dist/demos.html
         filename: 'demos.html',
         // chunks to include on this page, by default includes


### PR DESCRIPTION
Follow up on https://github.com/nimiq/hub/pull/445.
Please check whether this builds on Mac (@Yukiioz) and Windows (@neokrept).

While changing `vue.config.js` I also added a small change for not copying `browser-warning.html.template` over to the dist folder, although not strictly related to this PR.