### PR TITLE
Temporarily circumvent Desktop Safari resource integrity check bug client-side

### DIFF
--- a/public/ServiceWorker.js
+++ b/public/ServiceWorker.js
@@ -18,31 +18,33 @@ self.addEventListener('fetch', event => {
     // See: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Cross-origin_data_storage_access
     // @ts-ignore Property 'request' does not exist on type 'Event'.ts
     const requestHost = new URL(event.request.url).host;
+    if (requestHost !== location.host) return;
 
     let headers = event.request.headers;
     // Check whether a resource specifies an integrity hash.
-    if (event.request.integrity != '') {
+    if (event.request.integrity) {
         // Create a duplicate of the request headers, since these are read-only now.
-        headers = new Headers();
-        for (const [key, value] of event.request.headers.entries()) {
-            // Drop all headers that could trigger a "304 - Not modified" HTTP response.
-            // This helps to prevent Desktop Safari from being unable to verify the
-            // integrity of the fetched ressource due to a seemingly empty response... :-/
-            if (key != 'if-modified-since' && key != 'if-none-match') {
-                headers.set(key, value);
-            }
-        }
+        headers = new Headers(event.request.headers);
+        // Drop all headers that could trigger a "304 - Not modified" HTTP response.
+        // This helps to prevent Desktop Safari from being unable to verify the
+        // integrity of the fetched resource due to a seemingly empty response... :-/
+        // Note that currently, the ServiceWorker is only installed for Safari, therefore
+        // we don't need to check for the browser here to apply this fix selectively for
+        // Safari only.
+        // TODO: check in the future whether Safari still needs this special treatment
+        headers.delete('If-Match');
+        headers.delete('If-None-Match');
+        headers.delete('If-Modified-Since');
+        headers.delete('If-Unmodified-Since');
     }
 
-    if (requestHost === location.host) {
-        // forward request
-        // @ts-ignore Property 'respondWith' does not exist on type 'Event'.ts,
-        // Property 'request' does not exist on type 'Event'.ts
-        event.respondWith(fetch(event.request, {
-            // omit cookie transmission
-            credentials: 'omit',
-            // override headers as they've might changed
-            headers: headers
-        }));
-    }
+    // forward request
+    // @ts-ignore Property 'respondWith' does not exist on type 'Event'.ts,
+    // Property 'request' does not exist on type 'Event'.ts
+    event.respondWith(fetch(event.request, {
+        // omit cookie transmission
+        credentials: 'omit',
+        // override headers as they might have changed
+        headers,
+    }));
 });


### PR DESCRIPTION
ServiceWorker.js: drop all headers from request that could trigger a HTTP 304 response

This commit contains a temporary workaround to deal with a bug in Desktop Safari
that prevents a successful resource integrity check when
  a resource is loaded via the service worker
  *and* the webpage forces cache revalidation (like we do).

When the resource is not modified, the server responds with a HTTP "304 -
Not modified" response. However, then Safari (supposedly) tries to check
the content from *this* response against the integrity hash *instead* of
the actual cached content. Obviously, this is pointless, since a HTTP
304 doesn't contain any content, because that would defer the entire
point, right? Hence, the integrity check won't ever succeed.. :-/

Therefore, we're now removing all headers from the request that could trigger
such a response. Addmitedly, that's less then ideal, since it effectiviely breaks
caching for all resources with an integrity check. However, these resources are
typically small and this patch is *intended* to be temporary.