### PR TITLE
Hub Client: add ios overlay behavior, since popup.focus() is ineffective

### DIFF
--- a/client/RequestBehavior.ts
+++ b/client/RequestBehavior.ts
@@ -1,6 +1,7 @@
 import { PostMessageRpcClient, RedirectRpcClient } from '@nimiq/rpc';
 import { ResultByRequestType, RequestType } from '../src/lib/PublicRequestTypes';
 import translate from './i18n/i18n';
+import { BrowserDetection } from '@nimiq/utils';
 
 export abstract class RequestBehavior<B extends BehaviorType> {
     public static getAllowedOrigin(endpoint: string) {
@@ -72,6 +73,10 @@ export class PopupRequestBehavior extends RequestBehavior<BehaviorType.POPUP> {
     private _popupFeatures: typeof PopupRequestBehavior.DEFAULT_FEATURES;
     private _options: typeof PopupRequestBehavior.DEFAULT_OPTIONS;
 
+    private shouldRetryRequest: boolean = false;
+    private popup: Window | undefined;
+    private client: PostMessageRpcClient | undefined;
+
     constructor(
         popupFeatures = PopupRequestBehavior.DEFAULT_FEATURES,
         options?: typeof PopupRequestBehavior.DEFAULT_OPTIONS,
@@ -91,25 +96,35 @@ export class PopupRequestBehavior extends RequestBehavior<BehaviorType.POPUP> {
     ): Promise<ResultByRequestType<R>> {
         const origin = RequestBehavior.getAllowedOrigin(endpoint);
 
-        const popup = this.createPopup(endpoint);
-
         // Add page overlay
-        const $overlay = this.appendOverlay(popup);
+        const $overlay = this.appendOverlay();
 
-        const client = new PostMessageRpcClient(popup, origin);
+        do {
+            this.shouldRetryRequest = false;
+            this.popup = this.createPopup(endpoint);
+            this.client = new PostMessageRpcClient(this.popup, origin);
 
-        try {
-            await client.init();
-            return await client.call(command, ...(await Promise.all(args)));
-        } catch (e) {
-            throw e;
-        } finally {
-            // Remove page overlay
-            this.removeOverlay($overlay);
+            try {
+                await this.client.init();
+                return await this.client.call(command, ...(await Promise.all(args)));
+            } catch (e) {
+                if (!this.shouldRetryRequest) throw e;
+            } finally {
+                if (!this.shouldRetryRequest) {
+                    // Remove page overlay
+                    this.removeOverlay($overlay);
 
-            client.close();
-            popup.close();
-        }
+                    this.client.close();
+                    this.popup.close();
+                }
+            }
+        } while (this.shouldRetryRequest);
+
+        // the code below should never be executed, unless unexpected things happend
+        if (this.popup) this.popup.close();
+        if (this.client) this.client.close();
+        if ($overlay) this.removeOverlay($overlay);
+        throw new Error('Unexpected error occurred');
     }
 
     public createPopup(url: string) {
@@ -120,7 +135,7 @@ export class PopupRequestBehavior extends RequestBehavior<BehaviorType.POPUP> {
         return popup;
     }
 
-    private appendOverlay(popup: Window): HTMLDivElement | null {
+    private appendOverlay(): HTMLDivElement | null {
         if (!this._options.overlay) return null;
 
         // Define DOM-method abstractions to allow better minification
@@ -147,7 +162,15 @@ export class PopupRequestBehavior extends RequestBehavior<BehaviorType.POPUP> {
         overlayStyle.opacity = '0';
         overlayStyle.transition = 'opacity 0.6s ease';
         overlayStyle.zIndex = '99999';
-        overlay.addEventListener('click', () => popup.focus());
+        overlay.addEventListener('click', () => {
+            if (BrowserDetection.isIOS()) {
+                this.shouldRetryRequest = true;
+                if (this.popup) this.popup.close();
+                if (this.client) this.client.close();
+            } else {
+                if (this.popup) this.popup.focus();
+            }
+        });
 
         // Top flex spacer
         appendChild(overlay, createElement('div'));
@@ -185,7 +208,9 @@ export class PopupRequestBehavior extends RequestBehavior<BehaviorType.POPUP> {
         buttonStyle.width = '32px';
         buttonStyle.height = '32px';
         buttonStyle.opacity = '0.8';
-        button.addEventListener('click', () => popup.close());
+        button.addEventListener('click', () => {
+            if (this.popup) this.popup.close();
+        });
         appendChild(overlay, button);
 
         // The 100ms delay is not just because the DOM element needs to be rendered before it

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@nimiq/core-web": "^1.5.3",
     "@nimiq/rpc": "^0.4.0",
+    "@nimiq/utils": "^0.5.0",
     "big-integer": "^1.6.48"
   },
   "devDependencies": {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -28,6 +28,13 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.4.0.tgz#d15f95c39d21c513172aa75c8f43ae555067cb50"
   integrity sha512-Zpv45kTnbhmr75xc8BK2o/K1gDBh3TcJwIuo95SWBoWmu4ntcKtHs744bfu6Lf49XGG8d+cFn2dPDDDIeoBfmw==
 
+"@nimiq/utils@^0.5.0":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.5.1.tgz#a5641e483e80b00066c3f2b0b85132974cf5c7e5"
+  integrity sha512-6p/oh6nzj/GVlcDn5WFJnSOoDgzGNoGLaR063wBvk+S672+p9sT4dhU2bCRWAY30cLhJsOL7X74QIus5weIpXA==
+  dependencies:
+    big-integer "^1.6.44"
+
 "@rollup/plugin-json@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
@@ -128,7 +135,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-big-integer@^1.6.48:
+big-integer@^1.6.44, big-integer@^1.6.48:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -190,12 +190,12 @@ msgid "By adding a transation fee, you can influence how fast your transaction w
 msgstr ""
 
 #: src/views/CashlinkManage.vue:11
-#: src/views/Checkout.vue:182
+#: src/views/Checkout.vue:184
 #: src/views/CheckoutTransmission.vue:10
 msgid "Cancel"
 msgstr ""
 
-#: src/views/Checkout.vue:181
+#: src/views/Checkout.vue:183
 #: src/views/SignTransactionLedger.vue:108
 msgid "Cancel payment"
 msgstr ""


### PR DESCRIPTION
When clicking on the overlay, now closing and reopening the popup for IOS instead of trying to focus it so that it doesn't look broken. 