### PR TITLE
Repopulate cookie when onboarding is called with accounts in the DB

### DIFF
--- a/src/lib/WalletStore.ts
+++ b/src/lib/WalletStore.ts
@@ -78,7 +78,7 @@ export class WalletStore extends Store<any, WalletInfoEntry> {
 
     public async list(): Promise<WalletInfoEntry[]> {
         this._storeName = WalletStore.DB_ACCOUNTS_STORE_NAME;
-        return super.list()  as Promise<WalletInfoEntry[]>;
+        return super.list() as Promise<WalletInfoEntry[]>;
     }
 
     protected upgrade(request: any, event: IDBVersionChangeEvent): void {

--- a/src/views/OnboardingSelector.vue
+++ b/src/views/OnboardingSelector.vue
@@ -21,7 +21,7 @@ import { BrowserDetection } from '@nimiq/utils';
 import GlobalClose from '../components/GlobalClose.vue';
 import OnboardingMenu from '../components/OnboardingMenu.vue';
 import { ParsedOnboardRequest } from '@/lib/RequestTypes';
-import { Account, RequestType } from '@/lib/PublicRequestTypes';
+import { RequestType } from '@/lib/PublicRequestTypes';
 import { Static } from '@/lib/StaticStore';
 import { DEFAULT_KEY_PATH, ERROR_CANCELED } from '@/lib/Constants';
 import CookieHelper from '../lib/CookieHelper';
@@ -30,6 +30,7 @@ import { BTC_ACCOUNT_KEY_PATH } from '../lib/bitcoin/BitcoinConstants';
 import Config from 'config';
 import CookieJar from '../lib/CookieJar';
 import { WalletStore } from '../lib/WalletStore';
+import { WalletInfo } from '../lib/WalletInfo';
 
 @Component({components: {GlobalClose, OnboardingMenu, NotEnoughCookieSpace}})
 export default class OnboardingSelector extends Vue {
@@ -52,7 +53,7 @@ export default class OnboardingSelector extends Vue {
 
                     const result = await Promise.all(
                         dbAccounts.map(async (entry) => {
-                            const walletInfo = await WalletStore.Instance.get(entry.id);
+                            const walletInfo = WalletInfo.fromObject(entry);
                             return walletInfo!.toAccountType();
                         }),
                     );


### PR DESCRIPTION
On iOS, especially when the Wallet is installed to homescreen, the Hub sometimes deletes its cookie, even before 7 days are over (it should not delete any data in a PWA context, but maybe because the Hub is a non-first-party domain to the PWA and opens in a webview, it is still affected?). The IndexedDB & local storage in the webview is still present then.

This deletion of the Hub cookie leads to the Wallet triggering the onboarding flow as a redirect (`disableBack: true`). This PR uses this and short-circuits the onboarding request by simply responding with a full list of accounts, which also sets the cookie (through the `_reply()` function in the `RpcApi`).