### PR TITLE
Change API to use a number array instead of a Uint8Array

### DIFF
--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -456,8 +456,8 @@ export interface SignMessageRequest extends BasicRequest {
 
 export interface SignedMessage {
     signer: string; // Userfriendly address
-    signerPublicKey: Uint8Array;
-    signature: Uint8Array;
+    signerPublicKey: number[];
+    signature: number[];
 }
 
 export interface Address {

--- a/docs/api-methods/30_sign-message.md
+++ b/docs/api-methods/30_sign-message.md
@@ -75,8 +75,8 @@ The method returns a `SignedMessage` object containing the following properties:
 ```javascript
 interface SignedMessage {
     signer: string;               // Userfriendly address
-    signerPublicKey: Uint8Array;  // The public key of the signer
-    signature: Uint8Array;        // Signature for the message
+    signerPublicKey: number[];  // The public key of the signer
+    signature: number[];        // Signature for the message
 }
 ```
 
@@ -103,8 +103,8 @@ Verifying a signed message with the [Nimiq Core library](https://www.npmjs.com/p
 could go like this:
 
 ```javascript
-const signature = new Nimiq.Signature(signedMessage.signature);
-const publicKey = new Nimiq.PublicKey(signedMessage.signerPublicKey);
+const signature = new Nimiq.Signature(new Uint8Array(signedMessage.signature));
+const publicKey = new Nimiq.PublicKey(new Uint8Array(signedMessage.signerPublicKey));
 
 // For string messages:
 const data = HubApi.MSG_PREFIX

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -25,8 +25,8 @@ export default class SignMessageSuccess extends Vue {
     private mounted() {
         const result: SignedMessage = {
             signer: new Nimiq.Address(this.keyguardRequest.signer).toUserFriendlyAddress(),
-            signerPublicKey: this.keyguardResult.publicKey,
-            signature: this.keyguardResult.signature,
+            signerPublicKey: Array.from(this.keyguardResult.publicKey),
+            signature: Array.from(this.keyguardResult.signature),
         };
 
         setTimeout(() => this.$rpc.resolve(result), StatusScreen.SUCCESS_REDIRECT_DELAY);


### PR DESCRIPTION
```
const clientObj: Uint8Array = new Uint8Array([21, 31]);
const message = JSON.stringify(clientObj)
console.log("clientObj", clientObj instanceof Uint8Array) 

const serverObj: Uint8Array = JSON.parse(message);
console.log("serverObj", serverObj instanceof Uint8Array) // returns false because Uint8Array is serialized as an object
```

With this change SignedMessage can be serialized and deserialized without problems. Its a breaking API change tho