### PR TITLE
Revert to more exhaustive address scanning

### DIFF
--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -65,10 +65,9 @@ export default class LoginSuccess extends Vue {
             await Promise.all(
                 this.keyguardResult.map(async (keyResult) => {
                     // The Keyguard always returns (at least) one derived Address,
-                    const keyguardResultAccounts = keyResult.addresses.map((addressObj, index) => ({
+                    const keyguardResultAccounts = keyResult.addresses.map((addressObj) => ({
                         address: new Nimiq.Address(addressObj.address).toUserFriendlyAddress(),
                         path: addressObj.keyPath,
-                        index,
                     }));
 
                     let tryCount = 0;
@@ -187,7 +186,6 @@ export default class LoginSuccess extends Vue {
 
     private onUpdate(walletInfo: WalletInfo, currentlyCheckedAccounts: BasicAccountInfo[]) {
         const count = !walletInfo ? 0 : walletInfo.accounts.size;
-        if (count <= 1) return;
         this.status = this.$tc('Imported {count} address so far... | Imported {count} addresses so far...', count);
     }
 


### PR DESCRIPTION
`f4b5904f` ("Improve syncing/detection during login") changed address scanning to strictly allow an address gap of at most `ACCOUNT_MAX_ALLOWED_ADDRESS_GAP`. Now that the more exhaustive scanning is no problem anymore with the recent performance improvements of `@nimiq/core`, we can revert this to the old implementation which is less restrictive by always checking full chunks of size `ACCOUNT_MAX_ALLOWED_ADDRESS_GAP`, which can result in address gaps between `ACCOUNT_MAX_ALLOWED_ADDRESS_GAP` and `2*ACCOUNT_MAX_ALLOWED_ADDRESS_GAP-1`. This allows to potentially find more of the user's addresses.

Reverting the commit also fixes the lint error for overlong lines, that #554 intended to fix.
The more detailed status messages in `LoginSuccess` of `f4b5904f` have not been reverted as the only remaining change of that commit.

However, all that being said, we could also consider increasing `ACCOUNT_MAX_ALLOWED_ADDRESS_GAP` instead, to more consistently increase the search range.