### PR TITLE
Fix Ledger confirm-address screen rendering

### DIFF
--- a/src/components/LedgerUi.vue
+++ b/src/components/LedgerUi.vue
@@ -525,7 +525,7 @@ export default LedgerUi;
     }
 
     .ledger-screen-confirm-address {
-        background-image: url('data:image/svg+xml,svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 114 37.5"><text font-family="sans-serif" font-size="11" transform="translate(36.5 16.5)"><tspan x="0" y="0">Confirm </tspan><tspan x="-.9" y="12">Address</tspan></text><path fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.2 21.2l-5.5-5.5m5.5.1l-5.5 5.5m98.5-5.5l-5.5 5.5-2.5-2.5"/></svg>');
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 114 37.5"><text font-family="sans-serif" font-size="11" transform="translate(36.5 16.5)"><tspan x="0" y="0">Confirm </tspan><tspan x="-.9" y="12">Address</tspan></text><path fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.2 21.2l-5.5-5.5m5.5.1l-5.5 5.5m98.5-5.5l-5.5 5.5-2.5-2.5"/></svg>');
     }
 
     .ledger-device-container[illustration="confirm-address"] .ledger-screen-confirm-address {


### PR DESCRIPTION
## What

Restore the missing `<` in the confirm-address SVG data URI.

## Why

The malformed URI cannot be parsed as SVG, leaving the Ledger confirm-address screen blank.

## Validation

- `yarn lint`
- `yarn tsc --noEmit --skipLibCheck`
- `yarn test:unit --runInBand --no-watchman` — 19 passed, 5 skipped
- Chromium data-URI probe — loaded at 300×99

`yarn build:ci` remains blocked by existing `Symbol.dispose` errors in `client/node_modules/@nimiq/core/types/wasm/bundler.d.ts`.

Closes #581
