### PR TITLE
Offer a new address from the ChooseAddress picker

### DIFF
--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Login successful"
 msgstr ""
 
-#: src/views/ChooseAddress.vue:67
+#: src/views/ChooseAddress.vue:73
 #: src/views/ConnectAccount.vue:40
 msgid "Login to another account"
 msgstr ""
@@ -1239,6 +1239,10 @@ msgstr ""
 
 #: src/views/ActivatePolygonSuccess.vue:117
 msgid "USDC/USDT activated"
+msgstr ""
+
+#: src/views/ChooseAddress.vue:40
+msgid "Use a new address"
 msgstr ""
 
 #: src/components/OnboardingMenu.vue:12

--- a/src/views/AddAccount.vue
+++ b/src/views/AddAccount.vue
@@ -4,6 +4,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
+import { State } from 'vuex-class';
 import { DeriveAddressRequest } from '@nimiq/keyguard-client';
 import { BrowserDetection } from '@nimiq/utils';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
@@ -17,10 +18,20 @@ import NotEnoughCookieSpace from '../components/NotEnoughCookieSpace.vue';
 export default class AddAccount extends Vue {
     @Static private request!: ParsedSimpleRequest;
 
+    @State private activeWalletId!: string | null;
+
     private notEnoughCookieSpace = false;
 
     public async created() {
-        const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
+        // An add-address request names its wallet. When this view is reached from another
+        // flow (ChooseAddress), the inherited request is that flow's and has no walletId, so
+        // the account is the active one instead.
+        const walletId = this.request.walletId || this.activeWalletId;
+        const wallet = walletId ? await WalletStore.Instance.get(walletId) : undefined;
+        if (!wallet) {
+            this.$rpc.reject(new Error('Account not found'));
+            return;
+        }
         if (wallet.type === WalletType.LEGACY) {
             this.$rpc.reject(new Error('Cannot add address to single-address account'));
             return;

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -35,6 +35,12 @@
                 @account-selected="accountSelected"
                 @login="() => goToOnboarding(false)"/>
 
+            <PageFooter v-if="addressCreationWallet">
+                <button class="nq-button-s" @click="addAddress">
+                    {{ $t('Use a new address') }}
+                </button>
+            </PageFooter>
+
             <template v-if="!preSelectedWallet && request.ui === 2">
                 <PageBody>
                     <div class="account-selector">
@@ -95,9 +101,10 @@ import Config from 'config';
 import BitcoinSyncBaseView from './BitcoinSyncBaseView.vue';
 import StatusScreen from '../components/StatusScreen.vue';
 import GlobalClose from '../components/GlobalClose.vue';
-import { ChooseAddressResult, RequestType } from '../../client/PublicRequestTypes';
+import { Address, ChooseAddressResult, RequestType, RpcResult } from '../../client/PublicRequestTypes';
 import { ParsedChooseAddressRequest } from '../lib/RequestTypes';
 import staticStore, { Static } from '../lib/StaticStore';
+import { WalletStore } from '../lib/WalletStore';
 import { WalletInfo } from '../lib/WalletInfo';
 import { AccountInfo } from '../lib/AccountInfo';
 import { ContractInfo } from '../lib/ContractInfo';
@@ -122,11 +129,13 @@ import LedgerIcon from '../components/icons/LedgerIcon.vue';
 }})
 export default class ChooseAddress extends BitcoinSyncBaseView {
     @Static private request!: ParsedChooseAddressRequest;
+    @Static private sideResult?: RpcResult | Error;
 
     @Getter private findWallet!: (id: string) => WalletInfo | undefined;
     @Getter private processedWallets!: WalletInfo[];
 
     @State private wallets!: WalletInfo[];
+    @State private activeWalletId!: string | null;
 
     private AccountType = AccountType;
     private preSelectedWallet: WalletInfo | null = null;
@@ -136,10 +145,60 @@ export default class ChooseAddress extends BitcoinSyncBaseView {
         userFriendlyAddress: string,
     }) => any;
 
+    @Mutation('addWallet') private $addWallet!: (walletInfo: WalletInfo) => any;
+
     public async created() {
+        // Coming back from the add-address flow started below. The new address is already
+        // stored, but our copy of the wallet in the Vuex store predates it, so re-read it
+        // before resolving with an address that would otherwise look unknown.
+        if (this.sideResult && !(this.sideResult instanceof Error) && 'address' in this.sideResult) {
+            const { address } = this.sideResult as Address;
+            delete staticStore.sideResult;
+
+            const wallet = this.activeWalletId
+                ? await WalletStore.Instance.get(this.activeWalletId)
+                : undefined;
+            if (wallet && wallet.accounts.has(address)) {
+                this.$addWallet(wallet);
+                this.accountSelected(wallet.id, address);
+                return;
+            }
+            // The address did not arrive where it was expected. Fall through to the picker
+            // rather than resolving with something we cannot describe.
+        }
+
         if (this.processedWallets.length === 0) {
             this.goToOnboarding(true);
         }
+    }
+
+    /**
+     * The account a new address would be added to, or null when that is not a single
+     * answer. Only offered for BIP39 accounts: a legacy account holds exactly one address
+     * and a Ledger needs its own flow, which `AddAccount` already refuses and routes.
+     */
+    private get addressCreationWallet(): WalletInfo | null {
+        if (this.preSelectedWallet) {
+            return this.preSelectedWallet.type === AccountType.BIP39 ? this.preSelectedWallet : null;
+        }
+        if (this.request.ui === 2) return null; // still choosing an account, not an address
+        const candidates = this.processedWallets.filter((wallet) => wallet.type === AccountType.BIP39);
+        return candidates.length === 1 ? candidates[0] : null;
+    }
+
+    private addAddress() {
+        const wallet = this.addressCreationWallet;
+        if (!wallet) return;
+
+        // `AddAccount` reads the wallet to derive from off the active account, because the
+        // request it inherits here is a ChooseAddress request and carries no walletId.
+        this.$setActiveAccount({
+            walletId: wallet.id,
+            userFriendlyAddress: wallet.accounts.keys().next().value,
+        });
+
+        staticStore.originalRouteName = RequestType.CHOOSE_ADDRESS;
+        this.$router.push({name: RequestType.ADD_ADDRESS});
     }
 
     private async accountSelected(walletId: string, address: string) {


### PR DESCRIPTION
## The problem

An app that needs a *fresh* address, rather than any existing one, cannot ask for it. It has
to tell the user to leave, open the Nimiq Wallet, use "Add address", name it, come back, and
run `chooseAddress` again. `addAddress` is Nimiq-only by design (`RpcApi.ts:60`), and that is
not what this asks to change.

The case I hit is one address per child in a family allowance app, so the seam repeats per
child on first run. Anything that assigns an address a role rather than reusing the user's
main one has the same shape: an escrow slot, a per-invoice address, a shared household jar.

## What this does

Adds a footer button to `ChooseAddress` that runs the add-address flow already in the Hub and
comes back with the new address selected.

The routing is the pattern the same view already uses for login. `goToOnboarding` sets
`staticStore.originalRouteName = RequestType.CHOOSE_ADDRESS` and pushes `ONBOARD`; `_reply`
then stores the result in `sideResult` and routes back. `addAddress` does the same thing one
route over, so `AddAccount` and `AddAccountSelection` are untouched apart from one fallback.

That precedent is the argument for it. `ChooseAddress` may already send a third-party caller
through `ONBOARD`, which is the one Account Management request explicitly kept off the
whitelist because it exposes internal `accountId`s. Deriving one more address is a smaller
action than creating or importing an account, and `ChooseAddress` resolves with an address and
a label, so no `accountId` is reachable this way.

## Scope

The button appears only when the account to add to is a single unambiguous answer:

- `ui === 2` after an account has been picked, or
- the default UI when exactly one BIP39 account exists

Legacy accounts hold one address, Ledger needs its own flow, and several accounts with no
selection has no correct target. In all of those the button is absent rather than failing
later.

`_3rdPartyRequestWhitelist` and `privilegedOrigins` are not touched. `addAddress` as an RPC
stays exactly as restricted as it is today.

## Two details worth review

**`AddAccount` reads the wallet off the request.** Reached this way it inherits a
`ChooseAddress` request, which carries no `walletId`, so it now falls back to the active
account, which `addAddress` sets before routing. The same change replaces a non-null assertion
on `WalletStore.get` with a rejection, since that lookup can now miss.

**Cancelling in the Keyguard cancels the whole request.** `_reply` deliberately does not honour
`originalRouteName` for `ERROR_CANCELED`, so backing out of the add-address step rejects the
`chooseAddress` call instead of returning to the picker. That matches what the existing
onboarding detour does today, so I left it alone, but returning to the picker is arguably
better for both.

## Verification

`yarn lint` and `yarn build:ci` pass. `yarn i18n:extract` picks up one new string, "Use a new
address", and the regenerated `en.po` is included.

`yarn test` fails here, and it fails the same way on an unmodified checkout: five suites die at
`require('@nimiq/core')` with `ReferenceError: TextDecoder is not defined`, which is the jsdom
environment on my Node, not this change. Same five before and after.

No unit test is added, because the existing suite covers stores and clients rather than views.

**Left as a draft because the flow has not been walked in a browser yet**, which needs a local
Keyguard and a BIP39 account. The parts that are only argued from source so far are the return
path (`sideResult` carrying `Address` back into `created`) and the wallet re-read, which exists
because `AddAccountSelection` persists through `WalletStore` without committing `addWallet`, so
the Vuex copy is stale on the way back. I will mark it ready once it is exercised. Review of
the approach before then is welcome, since that is the part worth arguing about.
