### PR TITLE
Multi-transaction signing for unstaking and validator switches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ package-lock.json
 *.sw*
 
 deployment-hub
+CLAUDE.md

--- a/client/HubApi.ts
+++ b/client/HubApi.ts
@@ -171,7 +171,7 @@ export default class HubApi<
     public signTransaction<B extends BehaviorType = DB>(
         request: Promise<SignTransactionRequest> | SignTransactionRequest,
         requestBehavior: RequestBehavior<B> = this._defaultBehavior as any,
-    ): Promise<B extends BehaviorType.REDIRECT ? void : SignedTransaction> {
+    ): Promise<B extends BehaviorType.REDIRECT ? void : SignedTransaction | SignedTransaction[]> {
         return this._request(requestBehavior, RequestType.SIGN_TRANSACTION, [request]);
     }
 

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -150,6 +150,9 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     sender: string;
     senderLabel?: string;
     recipientLabel?: string;
+    // For `'switch-validator'`, senderLabel and recipientLabel name the validators being
+    // switched between, so the staking address is labelled separately.
+    stakerLabel?: string;
     transactions: TransactionData[] | Uint8Array[];
     validatorAddress?: string;
     validatorImageUrl?: string;

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -153,11 +153,10 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     transactions: TransactionData[] | Uint8Array[];
     validatorAddress?: string;
     validatorImageUrl?: string;
-    amount?: number;
     // `'switch-validator'` switches the Keyguard view from the multi-tx list to a stacked
     // from→to validator card layout, and requires fromValidator* metadata below.
-    // `'unstaking'` switches to a validator → user-wallet stacked layout with the unstake amount,
-    // and requires `validatorAddress` plus exactly 3 transactions
+    // `'unstaking'` switches to a validator → user-wallet stacked layout, and requires
+    // `validatorAddress` plus exactly 3 transactions
     // (set-active-stake, retire-stake, remove-stake).
     layout?: 'switch-validator' | 'unstaking';
     fromValidatorAddress?: string;

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -117,7 +117,23 @@ export interface ChooseAddressResult extends Address {
     };
 }
 
-export interface SignTransactionRequest extends BasicRequest {
+// Transaction data without sender address (sender address is at request level)
+export interface TransactionData {
+    recipient: string;
+    recipientType?: Nimiq.AccountType;
+    recipientLabel?: string;
+    value: number;
+    fee?: number;
+    extraData?: Bytes;
+    flags?: number;
+    validityStartHeight: number; // FIXME To be made optional when hub has its own network
+    // Optional fields for staking transactions
+    senderType?: Nimiq.AccountType;
+    senderLabel?: string;
+}
+
+// Single transaction request (backward compatible - inline fields)
+export interface SignTransactionRequestSingle extends BasicRequest {
     sender: string;
     recipient: string;
     recipientType?: Nimiq.AccountType;
@@ -128,6 +144,16 @@ export interface SignTransactionRequest extends BasicRequest {
     flags?: number;
     validityStartHeight: number; // FIXME To be made optional when hub has its own network
 }
+
+// Multi-transaction request (array format)
+export interface SignTransactionRequestMulti extends BasicRequest {
+    sender: string;
+    senderLabel?: string; // Label for sender (for staking transactions)
+    recipientLabel?: string; // Label for first recipient (for UI display)
+    transactions: TransactionData[] | Uint8Array[]; // Data objects or serialized transactions
+}
+
+export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestMulti;
 
 export interface SignStakingRequest extends BasicRequest {
     senderLabel?: string;
@@ -783,7 +809,7 @@ export type RpcRequest = SignTransactionRequest
                        | ConnectAccountRequest;
 
 export type RpcResult = SignedTransaction
-                      | SignedTransaction[]
+                      | SignedTransaction[] // Can be returned by SIGN_TRANSACTION (multi-tx) or SIGN_STAKING
                       | PartialSignature
                       | Account
                       | Account[]
@@ -807,7 +833,7 @@ export type ResultByRequestType<T> =
     T extends RequestType.LIST_CASHLINKS ? Cashlink[] :
     T extends RequestType.CHOOSE_ADDRESS ? ChooseAddressResult :
     T extends RequestType.ADD_ADDRESS ? Address :
-    T extends RequestType.SIGN_TRANSACTION ? SignedTransaction :
+    T extends RequestType.SIGN_TRANSACTION ? SignedTransaction | SignedTransaction[] :
     T extends RequestType.SIGN_MULTISIG_TRANSACTION ? PartialSignature :
     T extends RequestType.SIGN_STAKING ? SignedTransaction[] :
     T extends RequestType.CHECKOUT ? SignedTransaction | SimpleResult :

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -156,7 +156,10 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     amount?: number;
     // `'switch-validator'` switches the Keyguard view from the multi-tx list to a stacked
     // from→to validator card layout, and requires fromValidator* metadata below.
-    layout?: 'switch-validator';
+    // `'unstaking'` switches to a validator → user-wallet stacked layout with the unstake amount,
+    // and requires `validatorAddress` plus exactly 3 transactions
+    // (set-active-stake, retire-stake, remove-stake).
+    layout?: 'switch-validator' | 'unstaking';
     fromValidatorAddress?: string;
     fromValidatorImageUrl?: string;
 }

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -117,19 +117,22 @@ export interface ChooseAddressResult extends Address {
     };
 }
 
-// Transaction data without sender address (sender address is at request level)
-export interface TransactionData {
-    recipient: string;
-    recipientType?: Nimiq.AccountType;
-    recipientLabel?: string;
-    value: number;
-    fee?: number;
-    extraData?: Bytes;
+/**
+ * Info for a single transaction entry of a request's `transactions` array. Mirrors the Keyguard's TransactionInfo (see
+ * Keyguard client/src/PublicRequest.ts), except that entries carry no sender address: the request-level `sender`
+ * determines the signer for all transactions and is inherited by all entries. As in the Keyguard, entries carry no
+ * labels; for requests with a single transaction, labels can be set at the request level.
+ */
+export interface TransactionInfo {
+    senderType?: Nimiq.AccountType; // Defaults to Nimiq.AccountType.Basic
+    senderData?: Bytes;
+    recipient: string; // A user-friendly or hex address, or the pseudo recipient `'CONTRACT_CREATION'`
+    recipientType?: Nimiq.AccountType; // Defaults to Nimiq.AccountType.Basic
+    recipientData?: Bytes;
+    value: number; // Luna
+    fee?: number; // Luna, defaults to 0
     flags?: number;
     validityStartHeight: number; // FIXME To be made optional when hub has its own network
-    // Optional fields for staking transactions
-    senderType?: Nimiq.AccountType;
-    senderLabel?: string;
 }
 
 // Single transaction request (backward compatible - inline fields)
@@ -145,28 +148,52 @@ export interface SignTransactionRequestSingle extends BasicRequest {
     validityStartHeight: number; // FIXME To be made optional when hub has its own network
 }
 
-// Multi-transaction request (array format)
-export interface SignTransactionRequestMulti extends BasicRequest {
+export interface SignTransactionRequestStandard extends BasicRequest {
+    layout?: 'standard';
+    sender: string; // inherited for all TransactionInfo entries
+    transactions: Array<TransactionInfo | Uint8Array>;
+    // Only applied for requests with a single transaction; for multiple transactions, plain addresses are displayed
+    // (same as in the Keyguard). Note that there is no senderLabel: the sender is the user's own account, for which the
+    // label is taken from the user's account data.
+    recipientLabel?: string;
+}
+
+// `'switch-validator'` is a simplified multi-transaction request representing a switch from an old validator to a new
+// validator that is rendered via a special layout in the Keyguard. It requires exactly two transactions in order:
+// set-active-stake, update-staker (enforced at parse time).
+export interface SignTransactionRequestSwitchValidator extends BasicRequest {
+    layout: 'switch-validator';
     sender: string;
+    transactions: Array<TransactionInfo | Uint8Array>;
+    // senderLabel and recipientLabel name the validators being switched between. The staking address is labeled
+    // separately via stakerLabel.
     senderLabel?: string;
     recipientLabel?: string;
-    // For `'switch-validator'`, senderLabel and recipientLabel name the validators being
-    // switched between, so the staking address is labelled separately.
     stakerLabel?: string;
-    transactions: TransactionData[] | Uint8Array[];
-    validatorAddress?: string;
+    // No validatorAddress: the validator being switched to is derived from the signed update-staker
+    // transaction's newDelegation, so that what is displayed is what gets signed.
     validatorImageUrl?: string;
-    // `'switch-validator'` switches the Keyguard view from the multi-tx list to a stacked
-    // from→to validator card layout, and requires fromValidator* metadata below.
-    // `'unstaking'` switches to a validator → user-wallet stacked layout, and requires
-    // `validatorAddress` plus exactly 3 transactions
-    // (set-active-stake, retire-stake, remove-stake).
-    layout?: 'switch-validator' | 'unstaking';
-    fromValidatorAddress?: string;
+    fromValidatorAddress: string;
     fromValidatorImageUrl?: string;
 }
 
-export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestMulti;
+// `'unstaking'` is a simplified multi-transaction request representing unstaking of staked funds to the user's address
+// that is rendered via a special layout in the Keyguard. It requires exactly three transactions in order:
+// set-active-stake, retire-stake, remove-stake (enforced at parse time).
+export interface SignTransactionRequestUnstaking extends BasicRequest {
+    layout: 'unstaking';
+    sender: string;
+    transactions: Array<TransactionInfo | Uint8Array>;
+    senderLabel?: string; // labels the validator
+    recipientLabel?: string; // labels the user
+    validatorAddress: string;
+    validatorImageUrl?: string;
+}
+
+export type SignTransactionRequest = SignTransactionRequestSingle
+    | SignTransactionRequestStandard
+    | SignTransactionRequestSwitchValidator
+    | SignTransactionRequestUnstaking;
 
 export interface SignStakingRequest extends BasicRequest {
     senderLabel?: string;
@@ -851,6 +878,8 @@ export type ResultByRequestType<T> =
     T extends RequestType.LIST_CASHLINKS ? Cashlink[] :
     T extends RequestType.CHOOSE_ADDRESS ? ChooseAddressResult :
     T extends RequestType.ADD_ADDRESS ? Address :
+    // SIGN_TRANSACTION returns a single SignedTransaction iff a single transaction was signed (also for a
+    // one-element transactions array), and an array for multiple transactions.
     T extends RequestType.SIGN_TRANSACTION ? SignedTransaction | SignedTransaction[] :
     T extends RequestType.SIGN_MULTISIG_TRANSACTION ? PartialSignature :
     T extends RequestType.SIGN_STAKING ? SignedTransaction[] :

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -148,9 +148,17 @@ export interface SignTransactionRequestSingle extends BasicRequest {
 // Multi-transaction request (array format)
 export interface SignTransactionRequestMulti extends BasicRequest {
     sender: string;
-    senderLabel?: string; // Label for sender (for staking transactions)
-    recipientLabel?: string; // Label for first recipient (for UI display)
-    transactions: TransactionData[] | Uint8Array[]; // Data objects or serialized transactions
+    senderLabel?: string;
+    recipientLabel?: string;
+    transactions: TransactionData[] | Uint8Array[];
+    validatorAddress?: string;
+    validatorImageUrl?: string;
+    amount?: number;
+    // `'switch-validator'` switches the Keyguard view from the multi-tx list to a stacked
+    // from→to validator card layout, and requires fromValidator* metadata below.
+    layout?: 'switch-validator';
+    fromValidatorAddress?: string;
+    fromValidatorImageUrl?: string;
 }
 
 export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestMulti;
@@ -159,6 +167,11 @@ export interface SignStakingRequest extends BasicRequest {
     senderLabel?: string;
     recipientLabel?: string;
     transaction: Uint8Array | Uint8Array[];
+    validatorAddress?: string;
+    fromValidatorAddress?: string;
+    validatorImageUrl?: string;
+    fromValidatorImageUrl?: string;
+    amount?: number;
 }
 
 export interface NimiqCheckoutRequest extends BasicRequest {

--- a/client/PublicRequestTypes.ts
+++ b/client/PublicRequestTypes.ts
@@ -165,11 +165,9 @@ export interface SignTransactionRequestSwitchValidator extends BasicRequest {
     layout: 'switch-validator';
     sender: string;
     transactions: Array<TransactionInfo | Uint8Array>;
-    // senderLabel and recipientLabel name the validators being switched between. The staking address is labeled
-    // separately via stakerLabel.
+    // senderLabel and recipientLabel name the validators being switched between.
     senderLabel?: string;
     recipientLabel?: string;
-    stakerLabel?: string;
     // No validatorAddress: the validator being switched to is derived from the signed update-staker
     // transaction's newDelegation, so that what is displayed is what gets signed.
     validatorImageUrl?: string;
@@ -185,7 +183,6 @@ export interface SignTransactionRequestUnstaking extends BasicRequest {
     sender: string;
     transactions: Array<TransactionInfo | Uint8Array>;
     senderLabel?: string; // labels the validator
-    recipientLabel?: string; // labels the user
     validatorAddress: string;
     validatorImageUrl?: string;
 }

--- a/client/dist/src/HubApi.d.ts
+++ b/client/dist/src/HubApi.d.ts
@@ -32,7 +32,7 @@ export default class HubApi<DB extends BehaviorType = BehaviorType.POPUP, IB ext
         version: 2;
     } ? SimpleResult | SignedTransaction : SignedTransaction>;
     chooseAddress<B extends BehaviorType = DB>(request: Promise<ChooseAddressRequest> | ChooseAddressRequest, requestBehavior?: RequestBehavior<B>): Promise<B extends BehaviorType.REDIRECT ? void : ChooseAddressResult>;
-    signTransaction<B extends BehaviorType = DB>(request: Promise<SignTransactionRequest> | SignTransactionRequest, requestBehavior?: RequestBehavior<B>): Promise<B extends BehaviorType.REDIRECT ? void : SignedTransaction>;
+    signTransaction<B extends BehaviorType = DB>(request: Promise<SignTransactionRequest> | SignTransactionRequest, requestBehavior?: RequestBehavior<B>): Promise<B extends BehaviorType.REDIRECT ? void : SignedTransaction | SignedTransaction[]>;
     signStaking<B extends BehaviorType = DB>(request: Promise<SignStakingRequest> | SignStakingRequest, requestBehavior?: RequestBehavior<B>): Promise<B extends BehaviorType.REDIRECT ? void : SignedTransaction[]>;
     signMessage<B extends BehaviorType = DB>(request: Promise<SignMessageRequest> | SignMessageRequest, requestBehavior?: RequestBehavior<B>): Promise<B extends BehaviorType.REDIRECT ? void : SignedMessage>;
     signBtcTransaction<B extends BehaviorType = DB>(request: Promise<SignBtcTransactionRequest> | SignBtcTransactionRequest, requestBehavior?: RequestBehavior<B>): Promise<B extends BehaviorType.REDIRECT ? void : SignedBtcTransaction>;

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -123,12 +123,23 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     senderLabel?: string;
     recipientLabel?: string;
     transactions: TransactionData[] | Uint8Array[];
+    validatorAddress?: string;
+    validatorImageUrl?: string;
+    amount?: number;
+    layout?: 'switch-validator';
+    fromValidatorAddress?: string;
+    fromValidatorImageUrl?: string;
 }
 export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestMulti;
 export interface SignStakingRequest extends BasicRequest {
     senderLabel?: string;
     recipientLabel?: string;
     transaction: Uint8Array | Uint8Array[];
+    validatorAddress?: string;
+    fromValidatorAddress?: string;
+    validatorImageUrl?: string;
+    fromValidatorImageUrl?: string;
+    amount?: number;
 }
 export interface NimiqCheckoutRequest extends BasicRequest {
     version?: 1;

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -95,17 +95,22 @@ export interface ChooseAddressResult extends Address {
         };
     };
 }
-export interface TransactionData {
+/**
+ * Info for a single transaction entry of a request's `transactions` array. Mirrors the Keyguard's TransactionInfo (see
+ * Keyguard client/src/PublicRequest.ts), except that entries carry no sender address: the request-level `sender`
+ * determines the signer for all transactions and is inherited by all entries. As in the Keyguard, entries carry no
+ * labels; for requests with a single transaction, labels can be set at the request level.
+ */
+export interface TransactionInfo {
+    senderType?: Nimiq.AccountType;
+    senderData?: Bytes;
     recipient: string;
     recipientType?: Nimiq.AccountType;
-    recipientLabel?: string;
+    recipientData?: Bytes;
     value: number;
     fee?: number;
-    extraData?: Bytes;
     flags?: number;
     validityStartHeight: number;
-    senderType?: Nimiq.AccountType;
-    senderLabel?: string;
 }
 export interface SignTransactionRequestSingle extends BasicRequest {
     sender: string;
@@ -118,19 +123,33 @@ export interface SignTransactionRequestSingle extends BasicRequest {
     flags?: number;
     validityStartHeight: number;
 }
-export interface SignTransactionRequestMulti extends BasicRequest {
+export interface SignTransactionRequestStandard extends BasicRequest {
+    layout?: 'standard';
     sender: string;
+    transactions: Array<TransactionInfo | Uint8Array>;
+    recipientLabel?: string;
+}
+export interface SignTransactionRequestSwitchValidator extends BasicRequest {
+    layout: 'switch-validator';
+    sender: string;
+    transactions: Array<TransactionInfo | Uint8Array>;
     senderLabel?: string;
     recipientLabel?: string;
     stakerLabel?: string;
-    transactions: TransactionData[] | Uint8Array[];
-    validatorAddress?: string;
     validatorImageUrl?: string;
-    layout?: 'switch-validator' | 'unstaking';
-    fromValidatorAddress?: string;
+    fromValidatorAddress: string;
     fromValidatorImageUrl?: string;
 }
-export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestMulti;
+export interface SignTransactionRequestUnstaking extends BasicRequest {
+    layout: 'unstaking';
+    sender: string;
+    transactions: Array<TransactionInfo | Uint8Array>;
+    senderLabel?: string;
+    recipientLabel?: string;
+    validatorAddress: string;
+    validatorImageUrl?: string;
+}
+export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestStandard | SignTransactionRequestSwitchValidator | SignTransactionRequestUnstaking;
 export interface SignStakingRequest extends BasicRequest {
     senderLabel?: string;
     recipientLabel?: string;

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -126,7 +126,7 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     validatorAddress?: string;
     validatorImageUrl?: string;
     amount?: number;
-    layout?: 'switch-validator';
+    layout?: 'switch-validator' | 'unstaking';
     fromValidatorAddress?: string;
     fromValidatorImageUrl?: string;
 }

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -60,7 +60,7 @@ export declare enum AccountType {
     BIP39 = 2,
     LEDGER = 3
 }
-export { 
+export {
 /** @deprecated Use AccountType instead */
 AccountType as WalletType, };
 export interface BasicRequest {
@@ -145,7 +145,6 @@ export interface SignTransactionRequestUnstaking extends BasicRequest {
     sender: string;
     transactions: Array<TransactionInfo | Uint8Array>;
     senderLabel?: string;
-    recipientLabel?: string;
     validatorAddress: string;
     validatorImageUrl?: string;
 }

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -95,7 +95,19 @@ export interface ChooseAddressResult extends Address {
         };
     };
 }
-export interface SignTransactionRequest extends BasicRequest {
+export interface TransactionData {
+    recipient: string;
+    recipientType?: Nimiq.AccountType;
+    recipientLabel?: string;
+    value: number;
+    fee?: number;
+    extraData?: Bytes;
+    flags?: number;
+    validityStartHeight: number;
+    senderType?: Nimiq.AccountType;
+    senderLabel?: string;
+}
+export interface SignTransactionRequestSingle extends BasicRequest {
     sender: string;
     recipient: string;
     recipientType?: Nimiq.AccountType;
@@ -106,6 +118,13 @@ export interface SignTransactionRequest extends BasicRequest {
     flags?: number;
     validityStartHeight: number;
 }
+export interface SignTransactionRequestMulti extends BasicRequest {
+    sender: string;
+    senderLabel?: string;
+    recipientLabel?: string;
+    transactions: TransactionData[] | Uint8Array[];
+}
+export type SignTransactionRequest = SignTransactionRequestSingle | SignTransactionRequestMulti;
 export interface SignStakingRequest extends BasicRequest {
     senderLabel?: string;
     recipientLabel?: string;
@@ -641,4 +660,4 @@ export interface SignedPolygonTransaction {
 }
 export type RpcRequest = SignTransactionRequest | SignMultisigTransactionRequest | SignStakingRequest | CreateCashlinkRequest | ManageCashlinkRequest | CheckoutRequest | BasicRequest | SimpleRequest | ChooseAddressRequest | OnboardRequest | RenameRequest | SignMessageRequest | ExportRequest | SignBtcTransactionRequest | AddBtcAddressesRequest | SignPolygonTransactionRequest | SetupSwapRequest | RefundSwapRequest | ConnectAccountRequest;
 export type RpcResult = SignedTransaction | SignedTransaction[] | PartialSignature | Account | Account[] | SimpleResult | ChooseAddressResult | Address | Cashlink | Cashlink[] | SignedMessage | ExportResult | SignedBtcTransaction | AddBtcAddressesResult | SignedPolygonTransaction | SetupSwapResult | ConnectedAccount;
-export type ResultByRequestType<T> = T extends RequestType.RENAME ? Account : T extends RequestType.ONBOARD | RequestType.SIGNUP | RequestType.LOGIN | RequestType.MIGRATE | RequestType.LIST ? Account[] : T extends RequestType.LIST_CASHLINKS ? Cashlink[] : T extends RequestType.CHOOSE_ADDRESS ? ChooseAddressResult : T extends RequestType.ADD_ADDRESS ? Address : T extends RequestType.SIGN_TRANSACTION ? SignedTransaction : T extends RequestType.SIGN_MULTISIG_TRANSACTION ? PartialSignature : T extends RequestType.SIGN_STAKING ? SignedTransaction[] : T extends RequestType.CHECKOUT ? SignedTransaction | SimpleResult : T extends RequestType.SIGN_MESSAGE ? SignedMessage : T extends RequestType.LOGOUT | RequestType.CHANGE_PASSWORD ? SimpleResult : T extends RequestType.EXPORT ? ExportResult : T extends RequestType.CREATE_CASHLINK | RequestType.MANAGE_CASHLINK ? Cashlink : T extends RequestType.SIGN_BTC_TRANSACTION ? SignedBtcTransaction : T extends RequestType.SIGN_POLYGON_TRANSACTION ? SignedPolygonTransaction : T extends RequestType.ACTIVATE_BITCOIN ? Account : T extends RequestType.ACTIVATE_POLYGON ? Account : T extends RequestType.ADD_BTC_ADDRESSES ? AddBtcAddressesResult : T extends RequestType.SETUP_SWAP ? SetupSwapResult : T extends RequestType.CONNECT_ACCOUNT ? ConnectedAccount : never;
+export type ResultByRequestType<T> = T extends RequestType.RENAME ? Account : T extends RequestType.ONBOARD | RequestType.SIGNUP | RequestType.LOGIN | RequestType.MIGRATE | RequestType.LIST ? Account[] : T extends RequestType.LIST_CASHLINKS ? Cashlink[] : T extends RequestType.CHOOSE_ADDRESS ? ChooseAddressResult : T extends RequestType.ADD_ADDRESS ? Address : T extends RequestType.SIGN_TRANSACTION ? SignedTransaction | SignedTransaction[] : T extends RequestType.SIGN_MULTISIG_TRANSACTION ? PartialSignature : T extends RequestType.SIGN_STAKING ? SignedTransaction[] : T extends RequestType.CHECKOUT ? SignedTransaction | SimpleResult : T extends RequestType.SIGN_MESSAGE ? SignedMessage : T extends RequestType.LOGOUT | RequestType.CHANGE_PASSWORD ? SimpleResult : T extends RequestType.EXPORT ? ExportResult : T extends RequestType.CREATE_CASHLINK | RequestType.MANAGE_CASHLINK ? Cashlink : T extends RequestType.SIGN_BTC_TRANSACTION ? SignedBtcTransaction : T extends RequestType.SIGN_POLYGON_TRANSACTION ? SignedPolygonTransaction : T extends RequestType.ACTIVATE_BITCOIN ? Account : T extends RequestType.ACTIVATE_POLYGON ? Account : T extends RequestType.ADD_BTC_ADDRESSES ? AddBtcAddressesResult : T extends RequestType.SETUP_SWAP ? SetupSwapResult : T extends RequestType.CONNECT_ACCOUNT ? ConnectedAccount : never;

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -122,6 +122,7 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     sender: string;
     senderLabel?: string;
     recipientLabel?: string;
+    stakerLabel?: string;
     transactions: TransactionData[] | Uint8Array[];
     validatorAddress?: string;
     validatorImageUrl?: string;

--- a/client/dist/src/PublicRequestTypes.d.ts
+++ b/client/dist/src/PublicRequestTypes.d.ts
@@ -125,7 +125,6 @@ export interface SignTransactionRequestMulti extends BasicRequest {
     transactions: TransactionData[] | Uint8Array[];
     validatorAddress?: string;
     validatorImageUrl?: string;
-    amount?: number;
     layout?: 'switch-validator' | 'unstaking';
     fromValidatorAddress?: string;
     fromValidatorImageUrl?: string;

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -26,6 +26,14 @@ import { Utf8Tools } from '@nimiq/utils';
 import { WalletType } from '../src/lib/Constants';
 import { WalletStore } from '../src/lib/WalletStore';
 
+// BitcoinJS is defined as a global variable in BitcoinJS.min.js loaded by demos/index.html
+declare global {
+    const BitcoinJS: typeof import('bitcoinjs-lib');
+    interface Window {
+        loadAlbatross(): Promise<typeof import('@nimiq/core')>;
+    }
+}
+
 class Demo {
     public static run() {
         const keyguardOrigin = location.origin === 'https://hub.v2.nimiq-testnet.com'
@@ -194,6 +202,41 @@ class Demo {
             }
         });
 
+        document.querySelector('button#sign-multi-transaction')!.addEventListener('click', async () => {
+            const txRequest = generateSignMultiTransactionRequest();
+            try {
+                const result = await demo.client.signTransaction(txRequest, demo._defaultBehavior);
+                if (demo.isRedirectResult(result)) return;
+                console.log('Result', result);
+                if (Array.isArray(result)) {
+                    document.querySelector('#result')!.textContent = `${result.length} transactions signed`;
+                } else {
+                    document.querySelector('#result')!.textContent = 'TX signed';
+                }
+            } catch (e) {
+                console.error(e);
+                document.querySelector('#result')!.textContent = `Error: ${e.message || e}`;
+            }
+        });
+
+        document.querySelector('button#sign-staking-multi-transaction')!.addEventListener('click', async () => {
+            const txRequest = await generateStakingMultiTransactionRequest();
+            try {
+                const result = await demo.client.signTransaction(txRequest, demo._defaultBehavior);
+                if (demo.isRedirectResult(result)) return;
+                console.log('Result', result);
+                if (Array.isArray(result)) {
+                    document.querySelector('#result')!.textContent =
+                        `${result.length} staking transactions signed (deactivate, retire, unstake)`;
+                } else {
+                    document.querySelector('#result')!.textContent = 'Staking TX signed';
+                }
+            } catch (e) {
+                console.error(e);
+                document.querySelector('#result')!.textContent = `Error: ${e.message || e}`;
+            }
+        });
+
         document.querySelector('button#onboard')!.addEventListener('click', async () => {
             try {
                 const result = await demo.client.onboard({ appName: 'Hub Demos' }, demo._defaultBehavior);
@@ -251,6 +294,118 @@ class Demo {
                 fee,
                 extraData: Utf8Tools.stringToUtf8ByteArray(txData),
                 validityStartHeight: parseInt(validityStartHeight, 10),
+            };
+        }
+
+        function generateSignMultiTransactionRequest(): SignTransactionRequest {
+            const $radio = document.querySelector('input[name="address"]:checked');
+            if (!$radio) {
+                alert('You have no account to send a tx from, create an account first (signup)');
+                throw new Error('No account found');
+            }
+            const sender = ($radio as HTMLElement).dataset.address!;
+            const baseFee = parseInt((document.querySelector('#fee') as HTMLInputElement).value, 10) || 100;
+            const validityStartHeight = parseInt((document.querySelector('#validitystartheight') as HTMLInputElement).value || '1234', 10);
+
+            // Sample recipients for multi-transaction demo
+            const recipients = [
+                'NQ63 U7XG 1YYE D6FA SXGG 3F5H X403 NBKN JLDU',
+                'NQ46 2RM7 QE4T 82KR 61Q9 9B7E R38G LBVM N6KY',
+                'NQ70 APBA 9GCC FL44 D82R UJCD DS4B Y824 3LYJ',
+            ];
+
+            return {
+                appName: 'Hub Demos',
+                sender,
+                recipientLabel: 'Alice',
+                transactions: recipients.map((recipient, index) => ({
+                    recipient,
+                    value: 100000000 + (index * 10000000), // 1 NIM + increments
+                    fee: baseFee + (index * 10),
+                    validityStartHeight: validityStartHeight + index,
+                    extraData: Utf8Tools.stringToUtf8ByteArray(`Multi-tx demo ${index + 1}`),
+                })),
+            };
+        }
+
+        async function generateStakingMultiTransactionRequest(): Promise<SignTransactionRequest> {
+            const $radio = document.querySelector('input[name="address"]:checked');
+            if (!$radio) {
+                alert('You have no account to send a tx from, create an account first (signup)');
+                throw new Error('No account found');
+            }
+            const sender = ($radio as HTMLElement).dataset.address!;
+            const validityStartHeight = parseInt((document.querySelector('#validitystartheight') as HTMLInputElement).value || '1234', 10);
+
+            // Load Nimiq library
+            const Nimiq = await window.loadAlbatross();
+
+            // Demo recipients for simulated multi-transaction staking flow
+            // Using the same recipients as in the regular multi-transaction demo (known valid addresses)
+            const recipients = [
+                'NQ63 U7XG 1YYE D6FA SXGG 3F5H X403 NBKN JLDU',
+                'NQ46 2RM7 QE4T 82KR 61Q9 9B7E R38G LBVM N6KY',
+                'NQ70 APBA 9GCC FL44 D82R UJCD DS4B Y824 3LYJ',
+            ];
+
+            // Parse sender address
+            const senderAddress = Nimiq.Address.fromString(sender);
+
+            // Network ID for testnet (5 for test-albatross, 1 for mainnet)
+            const networkId = 5;
+
+            // Create actual serialized transactions using Nimiq library
+            const serializedTransactions = [
+                // Transaction 1: Deactivate stake (demo)
+                new Nimiq.Transaction(
+                    senderAddress, // sender
+                    Nimiq.AccountType.Basic, // senderType
+                    new Uint8Array(0), // senderData
+                    Nimiq.Address.fromString(recipients[0]), // recipient
+                    Nimiq.AccountType.Basic, // recipientType
+                    Utf8Tools.stringToUtf8ByteArray('Deactivate stake (demo)'), // recipientData (extraData)
+                    50000000n, // value (0.5 NIM)
+                    100n, // fee
+                    Nimiq.TransactionFlag.None, // flag
+                    validityStartHeight, // validityStartHeight
+                    networkId, // networkId
+                ).serialize(),
+                // Transaction 2: Retire stake (demo)
+                new Nimiq.Transaction(
+                    senderAddress,
+                    Nimiq.AccountType.Basic,
+                    new Uint8Array(0),
+                    Nimiq.Address.fromString(recipients[1]),
+                    Nimiq.AccountType.Basic,
+                    Utf8Tools.stringToUtf8ByteArray('Retire stake (demo)'),
+                    50000000n, // 0.5 NIM
+                    100n, // fee
+                    Nimiq.TransactionFlag.None,
+                    validityStartHeight + 10, // Slightly later
+                    networkId,
+                ).serialize(),
+                // Transaction 3: Unstake complete (demo)
+                new Nimiq.Transaction(
+                    senderAddress,
+                    Nimiq.AccountType.Basic,
+                    new Uint8Array(0),
+                    Nimiq.Address.fromString(recipients[2]),
+                    Nimiq.AccountType.Basic,
+                    Utf8Tools.stringToUtf8ByteArray('Unstake complete (demo)'),
+                    50000000n, // 0.5 NIM
+                    100n, // fee
+                    Nimiq.TransactionFlag.None,
+                    validityStartHeight + 20,
+                    networkId,
+                ).serialize(),
+            ];
+
+            // Return request with serialized transactions
+            return {
+                appName: 'Hub Demos',
+                sender,
+                recipientLabel: 'Staking Demo Recipients',
+                transactions: serializedTransactions,
             };
         }
 

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -403,7 +403,6 @@ class Demo {
             return {
                 appName: 'Hub Demos',
                 sender,
-                recipientLabel: 'Staking Demo Recipients',
                 transactions: serializedTransactions,
             };
         }

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -317,13 +317,12 @@ class Demo {
             return {
                 appName: 'Hub Demos',
                 sender,
-                recipientLabel: 'Alice',
                 transactions: recipients.map((recipient, index) => ({
                     recipient,
                     value: 100000000 + (index * 10000000), // 1 NIM + increments
                     fee: baseFee + (index * 10),
                     validityStartHeight: validityStartHeight + index,
-                    extraData: Utf8Tools.stringToUtf8ByteArray(`Multi-tx demo ${index + 1}`),
+                    recipientData: Utf8Tools.stringToUtf8ByteArray(`Multi-tx demo ${index + 1}`),
                 })),
             };
         }

--- a/demos/index.html
+++ b/demos/index.html
@@ -90,6 +90,8 @@
     <br><button id="checkout" disabled>Checkout</button>
     <br><button id="multi-checkout" disabled>Multi Checkout</button>
     <br><button id="sign-transaction" disabled>Sign Transaction</button>
+    <br><button id="sign-multi-transaction" disabled>Sign Multiple Transactions</button>
+    <br><button id="sign-staking-multi-transaction" disabled>Sign Staking Multi-Tx (Demo)</button>
 </div>
 
 <div class="request">

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@nimiq/electrum-client": "https://github.com/nimiq/electrum-client#build",
         "@nimiq/fastspot-api": "^1.10.2",
         "@nimiq/iqons": "^1.5.2",
-        "@nimiq/keyguard-client": "^1.10.0",
+        "@nimiq/keyguard-client": "^1.11.1",
         "@nimiq/ledger-api": "^4.0.0",
         "@nimiq/oasis-api": "^1.1.1",
         "@nimiq/rpc": "^0.4.1",

--- a/src/components/LedgerUi.vue
+++ b/src/components/LedgerUi.vue
@@ -2,10 +2,30 @@
     <div class="ledger-ui" :class="{
         small,
         'has-connect-button': showConnectButton,
+        'has-signing-step': showSigningStep,
         'is-wrong-app-connected': wrongAppConnected,
     }">
-        <StatusScreen :state="'loading'" :title="instructionsTitle" :status="instructionsText" :small="small">
+        <StatusScreen :state="'loading'" :title="instructionsTitle" :status="statusScreenStatus" :small="small">
             <template slot="loading">
+                <transition name="transition-fade">
+                    <div v-if="showSigningStep" class="signing-step">
+                        <template v-if="signingStep.totalSteps <= constructor.MAX_RENDERED_SIGNING_STEPS">
+                            <CheckmarkSmallIcon v-for="step in signingStep.step - 1" class="step"
+                                :key="`completed-step-${step}`" />
+                            <div class="step current-step">{{ signingStep.step }}</div>
+                            <div class="instructions">{{ signingStep.instructions }}</div>
+                            <div class="step" v-for="step in signingStep.totalSteps - signingStep.step"
+                                :key="`pending-step-${step}`">{{ step + signingStep.step }}</div>
+                        </template>
+                        <template v-else>
+                            <!-- An indicator per step would not fit; show a compact counter instead. -->
+                            <div class="step current-step compact-step">
+                                {{ signingStep.step }}/{{ signingStep.totalSteps }}
+                            </div>
+                            <div class="instructions">{{ signingStep.instructions }}</div>
+                        </template>
+                    </div>
+                </transition>
                 <transition name="transition-fade">
                     <LoadingSpinner v-if="illustration === constructor.Illustrations.LOADING"/>
                     <div v-else class="ledger-device-container"
@@ -46,7 +66,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-import { LoadingSpinner } from '@nimiq/vue-components';
+import { CheckmarkSmallIcon, LoadingSpinner } from '@nimiq/vue-components';
 import LedgerApi, {
     Coin,
     ErrorState,
@@ -62,13 +82,18 @@ import LedgerApi, {
 import Config from 'config';
 import StatusScreen from '../components/StatusScreen.vue';
 
-@Component({ components: { StatusScreen, LoadingSpinner } })
+@Component({ components: { StatusScreen, LoadingSpinner, CheckmarkSmallIcon } })
 class LedgerUi extends Vue {
     private static CONNECT_ANIMATION_STEP_DURATION = 9000 / 3;
+    private static MAX_RENDERED_SIGNING_STEPS = 8;
 
     @Prop(Boolean) public small?: boolean;
+    // Progress info for requests that consist of multiple consecutive Ledger interactions to be displayed as a step
+    // indicator at the top of the ui.
+    @Prop(Object) public signingStep?: LedgerUi.SigningStep;
 
     private state: State = LedgerApi.currentState;
+    private isIdleBetweenSigningSteps: boolean = false;
     private instructionsTitle: string = '';
     private instructionsText: string = '';
     private showConnectButton: boolean = false;
@@ -99,6 +124,19 @@ class LedgerUi extends Vue {
         } else {
             LedgerApi.connect(currentRequest.coin, currentRequest.network);
         }
+    }
+
+    private get showSigningStep(): boolean {
+        // Only display the step indicator while the Ledger is actually handling a request, or in between the
+        // consecutive requests of a multi request flow.
+        return !!this.signingStep
+            && (this.state.type === StateType.REQUEST_PROCESSING || this.isIdleBetweenSigningSteps);
+    }
+
+    private get statusScreenStatus(): string {
+        // While the signing step indicator is displayed, it replaces the regular instructions text on the small
+        // layout, on which the two would crowd the ui. The big layout has enough space for both.
+        return this.showSigningStep && this.small ? '' : this.instructionsText;
     }
 
     private get illustration() {
@@ -171,15 +209,25 @@ class LedgerUi extends Vue {
             this.connectTimer = window.setTimeout(() => {
                 if (LedgerApi.currentState.type !== StateType.CONNECTING) return;
                 this.state = LedgerApi.currentState;
+                this.isIdleBetweenSigningSteps = false;
             }, delay);
             return;
         }
         clearTimeout(this.connectTimer);
 
+        // Note that this.state still holds the previous state here, and that the state is only idle in between the
+        // consecutive requests of a multi request flow if the previous request just finished processing.
+        this.isIdleBetweenSigningSteps = !!this.signingStep
+            && this.state.type === StateType.REQUEST_PROCESSING // old state
+            && state.type === StateType.IDLE; // new state
         this.state = state;
         switch (state.type) {
             case StateType.IDLE:
-                this._showInstructions(null);
+                // Keep the instructions displayed in between the consecutive requests of a multi request flow, and
+                // also after its last one, for which the signing step indicator is kept displayed too. This avoids
+                // the ui blanking out between the steps, and again right before the view covers it on completion.
+                // They are cleared once the flow ends, see _onSigningStepChange.
+                if (!this.isIdleBetweenSigningSteps) this._showInstructions(null);
                 break;
             case StateType.LOADING:
                 this._onStateLoading();
@@ -236,7 +284,9 @@ class LedgerUi extends Vue {
             case RequestTypeNimiq.SIGN_TRANSACTION:
             case RequestTypeBitcoin.SIGN_TRANSACTION:
                 this._showInstructions(
-                    this.$t('Confirm Transaction') as string,
+                    this.signingStep
+                        ? this.$t('Confirm {count} Transactions', { count: this.signingStep.totalSteps }) as string
+                        : this.$t('Confirm Transaction') as string,
                     this.$t('Confirm using your Ledger') as string,
                 );
                 break;
@@ -322,6 +372,18 @@ class LedgerUi extends Vue {
         this.connectAnimationStep = (this.wrongAppConnected ? 2 : 0) + instructionIndex + 1;
     }
 
+    @Watch('signingStep')
+    private _onSigningStepChange(signingStep?: LedgerUi.SigningStep, previousSigningStep?: LedgerUi.SigningStep) {
+        if (!!signingStep === !!previousSigningStep) return;
+        // A flow started or ended, such that the api is not idle in between a flow's requests anymore.
+        this.isIdleBetweenSigningSteps = false;
+        if (!signingStep && this.state.type === StateType.IDLE) {
+            // The flow ended while the api is idle, i.e. the instructions of its last request, which were kept
+            // displayed as long as the flow was ongoing, are to be cleared now, see _onStateChange.
+            this._showInstructions(null);
+        }
+    }
+
     @Watch('illustration', { immediate: true })
     private _onIllustrationChange(illustration: string) {
         if (illustration === LedgerUi.Illustrations.CONNECTING) {
@@ -350,6 +412,12 @@ class LedgerUi extends Vue {
 }
 
 namespace LedgerUi {
+    export interface SigningStep {
+        step: number; // 1-based
+        totalSteps: number;
+        instructions: string;
+    }
+
     export const enum Events {
         NO_INFORMATION_SHOWN = 'no-information-shown',
         INFORMATION_SHOWN = 'information-shown',
@@ -394,6 +462,10 @@ export default LedgerUi;
         --ledger-y-offset: -3.5rem;
     }
 
+    .ledger-ui.has-signing-step {
+        --ledger-y-offset: 2.5rem;
+    }
+
     .status-screen {
         overflow: hidden;
     }
@@ -409,6 +481,60 @@ export default LedgerUi;
 
     .ledger-ui.has-connect-button.small .status-screen >>> .status-row {
         margin-bottom: 5.5rem;
+    }
+
+    /* Render signing steps in a similar visual style as we already had in SetupSwapLedger */
+    .signing-step {
+        position: absolute;
+        top: 11rem; /* Below the title, which is only rendered on the big layout, see _showInstructions. */
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0 1.5rem;
+        transition: opacity .4s;
+    }
+
+    .ledger-ui.small .signing-step {
+        top: 2.25rem;
+    }
+
+    .signing-step .step {
+        display: flex;
+        flex-shrink: 0;
+        width: 2.5rem;
+        height: 2.5rem;
+        margin: 0 .375rem;
+        border-radius: 1.25rem;
+        justify-content: center;
+        align-items: center;
+        font-size: 1.5rem;
+        font-weight: bold;
+        line-height: 1;
+        color: rgba(255, 255, 255, .5);
+        background: rgba(255, 255, 255, .1);
+    }
+
+    .signing-step .step.nq-icon {
+        margin: 0 .375rem;
+        padding: .75rem;
+    }
+
+    .signing-step .current-step {
+        color: white;
+    }
+
+    .signing-step .compact-step {
+        width: auto;
+        padding: 0 .875rem;
+    }
+
+    .signing-step .instructions {
+        font-size: 1.75rem;
+        font-weight: 600;
+        line-height: 1.2;
+        margin: 0 1rem 0 .625rem;
     }
 
     .connect-button {

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Cashlink created"
 msgstr ""
 
-#: src/views/CashlinkManage.vue:229
+#: src/views/CashlinkManage.vue:233
 msgid "Cashlink created."
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Creating your Account"
 msgstr ""
 
-#: src/views/CashlinkManage.vue:231
+#: src/views/CashlinkManage.vue:235
 #: src/views/SignTransactionLedger.vue:722
 msgid "Creating your Cashlink"
 msgstr ""
@@ -791,7 +791,7 @@ msgid "OASIS service fee"
 msgstr ""
 
 #: src/views/ErrorHandlerUnsupportedLedger.vue:4
-#: src/views/RefundSwapLedger.vue:359
+#: src/views/RefundSwapLedger.vue:360
 msgid "Ok"
 msgstr ""
 
@@ -908,11 +908,11 @@ msgstr ""
 msgid "Red Address"
 msgstr ""
 
-#: src/views/RefundSwapLedger.vue:329
+#: src/views/RefundSwapLedger.vue:330
 msgid "Refund Failed"
 msgstr ""
 
-#: src/views/RefundSwapLedger.vue:348
+#: src/views/RefundSwapLedger.vue:349
 msgid "Refunding this Swap is currently not supported on this device or browser. Please use the device and browser you originally created the Swap with. Otherwise please try again in the future."
 msgstr ""
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Single Accounts"
 msgstr ""
 
-#: src/views/CashlinkManage.vue:230
+#: src/views/CashlinkManage.vue:234
 #: src/views/CheckoutTransmission.vue:125
 msgid "Something went wrong"
 msgstr ""
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Swap Setup Failed"
 msgstr ""
 
-#: src/views/RefundSwapLedger.vue:327
+#: src/views/RefundSwapLedger.vue:328
 msgid "Syncing"
 msgstr ""
 
@@ -1070,11 +1070,11 @@ msgstr ""
 msgid "Syncing to network..."
 msgstr ""
 
-#: src/views/RefundSwapLedger.vue:343
+#: src/views/RefundSwapLedger.vue:344
 msgid "Syncing with {currency} network failed: {error}"
 msgstr ""
 
-#: src/views/RefundSwapLedger.vue:337
+#: src/views/RefundSwapLedger.vue:338
 msgid "Syncing with {currency} network..."
 msgstr ""
 
@@ -1177,12 +1177,12 @@ msgstr ""
 msgid "Transaction approved"
 msgstr ""
 
-#: src/views/CashlinkManage.vue:213
+#: src/views/CashlinkManage.vue:217
 #: src/views/CheckoutTransmission.vue:107
 msgid "Transaction could not be relayed"
 msgstr ""
 
-#: src/views/CashlinkManage.vue:211
+#: src/views/CashlinkManage.vue:215
 #: src/views/CheckoutTransmission.vue:105
 msgid "Transaction is expired"
 msgstr ""

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -401,6 +401,10 @@ msgstr ""
 msgid "Confirm Transaction"
 msgstr ""
 
+#: src/views/SignTransactionLedger.vue:987
+msgid "Confirm Transactions"
+msgstr ""
+
 #: src/views/SignTransactionLedger.vue:912
 msgid "Confirm update of staking setup"
 msgstr ""
@@ -1214,6 +1218,14 @@ msgstr ""
 #: src/views/SignBtcTransactionLedger.vue:116
 #: src/views/SignTransactionLedger.vue:726
 msgid "Transaction Signed"
+msgstr ""
+
+#: src/views/SignTransactionLedger.vue:1019
+msgid "Transactions Sent"
+msgstr ""
+
+#: src/views/SignTransactionLedger.vue:1015
+msgid "Transactions Signed"
 msgstr ""
 
 #: src/views/Migrate.vue:93

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -1018,7 +1018,7 @@ msgid "Speed up your transaction"
 msgstr ""
 
 #: src/views/SignStaking.vue:39
-#: src/views/SignStaking.vue:43
+#: src/views/SignStaking.vue:50
 msgid "Staking Contract"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -1017,8 +1017,8 @@ msgstr ""
 msgid "Speed up your transaction"
 msgstr ""
 
-#: src/views/SignStaking.vue:39
-#: src/views/SignStaking.vue:50
+#: src/views/SignStaking.vue:38
+#: src/views/SignStaking.vue:48
 msgid "Staking Contract"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -355,6 +355,10 @@ msgstr ""
 msgid "Collecting payment details"
 msgstr ""
 
+#: src/components/LedgerUi.vue:288
+msgid "Confirm {count} Transactions"
+msgstr ""
+
 #: src/views/SetupSwapLedger.vue:1006
 msgid "Confirm {outgoingOrIncoming} transaction on Ledger"
 msgstr ""

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -375,6 +375,14 @@ msgstr ""
 msgid "Confirm Message"
 msgstr ""
 
+#: src/views/SignTransactionLedger.vue:915
+msgid "Confirm retiring staked NIM"
+msgstr ""
+
+#: src/views/SignTransactionLedger.vue:909
+msgid "Confirm setting active stake amount"
+msgstr ""
+
 #: src/views/SetupSwapLedger.vue:5
 msgid "Confirm Swap"
 msgstr ""
@@ -393,9 +401,17 @@ msgstr ""
 msgid "Confirm Transaction"
 msgstr ""
 
+#: src/views/SignTransactionLedger.vue:912
+msgid "Confirm update of staking setup"
+msgstr ""
+
 #: src/components/LedgerUi.vue:240
 #: src/components/LedgerUi.vue:247
 msgid "Confirm using your Ledger"
+msgstr ""
+
+#: src/views/SignTransactionLedger.vue:961
+msgid "Confirm withdrawal of retired NIM"
 msgstr ""
 
 #: src/views/CashlinkReceive.vue:364

--- a/src/lib/Cashlink.ts
+++ b/src/lib/Cashlink.ts
@@ -414,7 +414,7 @@ class Cashlink {
             layout: 'cashlink',
             recipient: this.address,
             value: this.value,
-            fee: 0, // this.fee is meant for claiming transactions
+            fee: 0, // cashlink.fee is meant for claiming transactions
             recipientData: CashlinkExtraData.FUNDING,
             cashlinkMessage: this.message,
         };

--- a/src/lib/Cashlink.ts
+++ b/src/lib/Cashlink.ts
@@ -414,7 +414,9 @@ class Cashlink {
             layout: 'cashlink',
             recipient: this.address,
             value: this.value,
-            fee: 0, // cashlink.fee is meant for claiming transactions
+            // While the fee is also applied to the claiming transaction, see claim, it is also the fee the user chose
+            // for funding the Cashlink in CashlinkCreate.
+            fee: this.fee,
             recipientData: CashlinkExtraData.FUNDING,
             cashlinkMessage: this.message,
         };

--- a/src/lib/Constants.ts
+++ b/src/lib/Constants.ts
@@ -12,7 +12,6 @@ export const DEFAULT_KEY_PATH = `m/44'/242'/0'/0'`;
 // Transactions
 export const TX_MIN_VALIDITY_DURATION = 10;
 export const TX_VALIDITY_WINDOW = 120;
-export const CASHLINK_FUNDING_DATA = new Uint8Array([0, 130, 128, 146, 135]);
 
 // Labels
 export const LABEL_MAX_LENGTH = 63; // in bytes

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -19,6 +19,7 @@ import type {
     RpcRequest,
     SignMessageRequest,
     SignTransactionRequest,
+    SignTransactionRequestMulti,
     SignStakingRequest,
     SimpleRequest,
     NimiqCheckoutRequest,
@@ -122,6 +123,22 @@ export class RequestParser {
                             : firstPlainTx.recipientType === 'staking' ? Nimiq.AccountType.Staking
                             : Nimiq.AccountType.Basic;
 
+                        const multiTxRequest = signTransactionRequest as SignTransactionRequestMulti;
+                        if (multiTxRequest.layout === 'switch-validator') {
+                            if (plainTransactions.length !== 2) {
+                                throw new Error('switch-validator requires exactly two transactions');
+                            }
+                            const firstData = plainTransactions[0].data as { type?: string } | undefined;
+                            const secondData = plainTransactions[1].data as { type?: string } | undefined;
+                            if (firstData?.type !== 'set-active-stake'
+                                || secondData?.type !== 'update-staker') {
+                                throw new Error(
+                                    'switch-validator transactions must be '
+                                    + 'set-active-stake followed by update-staker',
+                                );
+                            }
+                        }
+
                         return {
                             kind: requestType,
                             appName: signTransactionRequest.appName,
@@ -142,10 +159,12 @@ export class RequestParser {
                             serializedTransactions,
                             senderLabel: signTransactionRequest.senderLabel,
                             isStakingRequest: isStakingTransactions, // Flag for SignTransaction.vue
-                            // Pass through staking-specific fields (for Keyguard display)
-                            validatorAddress: (signTransactionRequest as any).validatorAddress,
-                            validatorImageUrl: (signTransactionRequest as any).validatorImageUrl,
-                            amount: (signTransactionRequest as any).amount,
+                            validatorAddress: multiTxRequest.validatorAddress,
+                            validatorImageUrl: multiTxRequest.validatorImageUrl,
+                            amount: multiTxRequest.amount,
+                            layout: multiTxRequest.layout,
+                            fromValidatorAddress: multiTxRequest.fromValidatorAddress,
+                            fromValidatorImageUrl: multiTxRequest.fromValidatorImageUrl,
                         } as ParsedSignTransactionRequest;
                     } else {
                         // Transaction data objects format

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -137,6 +137,31 @@ export class RequestParser {
                                     + 'set-active-stake followed by update-staker',
                                 );
                             }
+                        } else if (multiTxRequest.layout === 'unstaking') {
+                            if (plainTransactions.length !== 3) {
+                                throw new Error('unstaking requires exactly three transactions');
+                            }
+                            const firstData = plainTransactions[0].data as { type?: string } | undefined;
+                            const secondData = plainTransactions[1].data as { type?: string } | undefined;
+                            if (firstData?.type !== 'set-active-stake'
+                                || secondData?.type !== 'retire-stake') {
+                                throw new Error(
+                                    'unstaking transactions must be set-active-stake, retire-stake, '
+                                    + 'remove-stake (in order)',
+                                );
+                            }
+                            // The third tx is `remove-stake`, an OUTGOING-staking tx whose recipient
+                            // is the user's basic wallet — its data has no parseable `type`.
+                            if (plainTransactions[2].senderType !== 'staking'
+                                || plainTransactions[2].recipientType !== 'basic') {
+                                throw new Error(
+                                    'third unstaking transaction must be remove-stake '
+                                    + '(staking → basic)',
+                                );
+                            }
+                            if (!multiTxRequest.validatorAddress) {
+                                throw new Error('unstaking requires validatorAddress');
+                            }
                         }
 
                         return {

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -19,7 +19,6 @@ import type {
     RpcRequest,
     SignMessageRequest,
     SignTransactionRequest,
-    SignTransactionRequestMulti,
     SignStakingRequest,
     SimpleRequest,
     NimiqCheckoutRequest,
@@ -56,6 +55,7 @@ import { ParsedEtherDirectPaymentOptions } from './paymentOptions/EtherPaymentOp
 import { ParsedBitcoinDirectPaymentOptions } from './paymentOptions/BitcoinPaymentOptions';
 import { Utf8Tools } from '@nimiq/utils';
 import Config from 'config';
+import { parseSignTransactionRequest, rawSignTransactionRequest } from './SignTransactionRequestParsing';
 import { SwapAsset } from '@nimiq/fastspot-api';
 import RpcApi from './RpcApi';
 
@@ -69,198 +69,7 @@ export class RequestParser {
 
         switch (requestType) {
             case RequestType.SIGN_TRANSACTION:
-                const signTransactionRequest = request as SignTransactionRequest;
-
-                // Check if it's a multi-transaction request
-                if ('transactions' in signTransactionRequest && signTransactionRequest.transactions) {
-                    // Multi-transaction format
-                    if (signTransactionRequest.transactions.length === 0) {
-                        throw new Error('transactions array must not be empty');
-                    }
-
-                    const firstTx = signTransactionRequest.transactions[0];
-
-                    // Check if transactions are serialized (Uint8Array[]) or data objects (TransactionData[])
-                    if (firstTx instanceof Uint8Array) {
-                        // Serialized transactions format (like signStaking)
-                        const serializedTransactions = signTransactionRequest.transactions as Uint8Array[];
-
-                        const plainTransactions = serializedTransactions.map((serializedTx) => {
-                            if (!(serializedTx instanceof Uint8Array)) {
-                                throw new Error('All transactions must be of type Uint8Array');
-                            }
-                            return Nimiq.Transaction.fromAny(serializedTx).toPlain();
-                        });
-
-                        // Check if these are staking transactions
-                        const isStakingTransactions = plainTransactions.every((tx) =>
-                            tx.senderType === 'staking' || tx.recipientType === 'staking',
-                        );
-
-                        // For staking transactions, validate constraints (like SignStaking does)
-                        if (isStakingTransactions) {
-                            if (plainTransactions.length < 1 || plainTransactions.length > 3) {
-                                throw new Error('Expected one to three staking transactions to sign');
-                            }
-
-                            for (const transaction of plainTransactions) {
-                                if (!(['staking', 'basic'] as const)
-                                    .every((type) => transaction.senderType === type
-                                        || transaction.recipientType === type)) {
-                                    throw new Error('Either sender or recipient needs to be of type staking, ' +
-                                        'and the other of type basic.');
-                                }
-                            }
-                        }
-
-                        // Use first transaction for compatibility fields
-                        const firstPlainTx = plainTransactions[0];
-
-                        // Convert string account type to enum
-                        const recipientType = firstPlainTx.recipientType === 'basic' ? Nimiq.AccountType.Basic
-                            : firstPlainTx.recipientType === 'vesting' ? Nimiq.AccountType.Vesting
-                            : firstPlainTx.recipientType === 'htlc' ? Nimiq.AccountType.HTLC
-                            : firstPlainTx.recipientType === 'staking' ? Nimiq.AccountType.Staking
-                            : Nimiq.AccountType.Basic;
-
-                        const multiTxRequest = signTransactionRequest as SignTransactionRequestMulti;
-                        if (multiTxRequest.layout === 'switch-validator') {
-                            if (plainTransactions.length !== 2) {
-                                throw new Error('switch-validator requires exactly two transactions');
-                            }
-                            const firstData = plainTransactions[0].data as { type?: string } | undefined;
-                            const secondData = plainTransactions[1].data as { type?: string } | undefined;
-                            if (firstData?.type !== 'set-active-stake'
-                                || secondData?.type !== 'update-staker') {
-                                throw new Error(
-                                    'switch-validator transactions must be '
-                                    + 'set-active-stake followed by update-staker',
-                                );
-                            }
-                            if (!multiTxRequest.validatorAddress) {
-                                throw new Error('switch-validator requires validatorAddress');
-                            }
-                            if (!multiTxRequest.fromValidatorAddress) {
-                                throw new Error('switch-validator requires fromValidatorAddress');
-                            }
-                        } else if (multiTxRequest.layout === 'unstaking') {
-                            if (plainTransactions.length !== 3) {
-                                throw new Error('unstaking requires exactly three transactions');
-                            }
-                            const firstData = plainTransactions[0].data as { type?: string } | undefined;
-                            const secondData = plainTransactions[1].data as { type?: string } | undefined;
-                            const thirdSenderData = plainTransactions[2]
-                                .senderData as { type?: string } | undefined;
-                            if (firstData?.type !== 'set-active-stake'
-                                || secondData?.type !== 'retire-stake'
-                                || thirdSenderData?.type !== 'remove-stake') {
-                                throw new Error(
-                                    'unstaking transactions must be set-active-stake, retire-stake, '
-                                    + 'remove-stake (in order)',
-                                );
-                            }
-                            // Bind all three transactions to the same staker so a caller can't
-                            // redirect the unbonded NIM to an attacker by setting tx2.recipient
-                            // to an arbitrary address while keeping benign labels.
-                            if (plainTransactions[0].sender !== plainTransactions[1].sender
-                                || plainTransactions[2].recipient !== plainTransactions[0].sender) {
-                                throw new Error(
-                                    'unstaking transactions must be bound to the same staker',
-                                );
-                            }
-                            if (!multiTxRequest.validatorAddress) {
-                                throw new Error('unstaking requires validatorAddress');
-                            }
-                        }
-
-                        return {
-                            kind: requestType,
-                            appName: signTransactionRequest.appName,
-                            sender: Nimiq.Address.fromString(signTransactionRequest.sender),
-                            recipient: Nimiq.Address.fromString(firstPlainTx.recipient),
-                            recipientType,
-                            recipientLabel: signTransactionRequest.recipientLabel,
-                            value: firstPlainTx.value,
-                            fee: firstPlainTx.fee,
-                            // For serialized transactions, data field is just for backward compatibility
-                            data: new Uint8Array(0),
-                            flags: firstPlainTx.flags,
-                            validityStartHeight: firstPlainTx.validityStartHeight,
-                            transactions: plainTransactions,
-                            // Store original serialized transactions
-                            // For staking: SignTransaction.vue will re-serialize from PlainTransaction
-                            // For non-staking: SignTransaction.vue will use these bytes directly
-                            serializedTransactions,
-                            senderLabel: signTransactionRequest.senderLabel,
-                            stakerLabel: multiTxRequest.stakerLabel,
-                            isStakingRequest: isStakingTransactions, // Flag for SignTransaction.vue
-                            validatorAddress: multiTxRequest.validatorAddress,
-                            validatorImageUrl: multiTxRequest.validatorImageUrl,
-                            layout: multiTxRequest.layout,
-                            fromValidatorAddress: multiTxRequest.fromValidatorAddress,
-                            fromValidatorImageUrl: multiTxRequest.fromValidatorImageUrl,
-                        } as ParsedSignTransactionRequest;
-                    } else {
-                        // Transaction data objects format
-                        type TransactionData = import('../../client/PublicRequestTypes').TransactionData;
-                        const transactionDataArray = signTransactionRequest.transactions as TransactionData[];
-                        const firstTxData = transactionDataArray[0];
-
-                        return {
-                            kind: requestType,
-                            appName: signTransactionRequest.appName,
-                            sender: Nimiq.Address.fromString(signTransactionRequest.sender),
-                            recipient: Nimiq.Address.fromString(firstTxData.recipient),
-                            recipientType: firstTxData.recipientType || Nimiq.AccountType.Basic,
-                            recipientLabel: signTransactionRequest.recipientLabel,
-                            value: firstTxData.value,
-                            fee: firstTxData.fee || 0,
-                            data: typeof firstTxData.extraData === 'string'
-                                ? Utf8Tools.stringToUtf8ByteArray(firstTxData.extraData)
-                                : firstTxData.extraData || new Uint8Array(0),
-                            flags: firstTxData.flags || Nimiq.TransactionFlag.None,
-                            validityStartHeight: firstTxData.validityStartHeight,
-                            transactions: transactionDataArray.map((tx) => ({
-                                recipient: Nimiq.Address.fromString(tx.recipient),
-                                recipientType: tx.recipientType || Nimiq.AccountType.Basic,
-                                recipientLabel: tx.recipientLabel,
-                                value: tx.value,
-                                fee: tx.fee || 0,
-                                data: typeof tx.extraData === 'string'
-                                    ? Utf8Tools.stringToUtf8ByteArray(tx.extraData)
-                                    : tx.extraData || new Uint8Array(0),
-                                flags: tx.flags || Nimiq.TransactionFlag.None,
-                                validityStartHeight: tx.validityStartHeight,
-                                // Staking-specific fields
-                                senderType: tx.senderType,
-                                senderLabel: tx.senderLabel,
-                            })),
-                            senderLabel: signTransactionRequest.senderLabel,
-                        } as ParsedSignTransactionRequest;
-                    }
-                } else {
-                    // Single transaction format (backward compatible)
-                    type SingleRequest = import('../../client/PublicRequestTypes').SignTransactionRequestSingle;
-                    const singleRequest = signTransactionRequest as SingleRequest;
-                    if (!singleRequest.value) throw new Error('value is required');
-                    if (!singleRequest.validityStartHeight) throw new Error('validityStartHeight is required');
-
-                    return {
-                        kind: requestType,
-                        appName: singleRequest.appName,
-                        sender: Nimiq.Address.fromString(singleRequest.sender),
-                        recipient: Nimiq.Address.fromString(singleRequest.recipient),
-                        recipientType: singleRequest.recipientType || Nimiq.AccountType.Basic,
-                        recipientLabel: singleRequest.recipientLabel,
-                        value: singleRequest.value,
-                        fee: singleRequest.fee || 0,
-                        data: typeof singleRequest.extraData === 'string'
-                            ? Utf8Tools.stringToUtf8ByteArray(singleRequest.extraData)
-                            : singleRequest.extraData || new Uint8Array(0),
-                        flags: singleRequest.flags || Nimiq.TransactionFlag.None,
-                        validityStartHeight: singleRequest.validityStartHeight,
-                    } as ParsedSignTransactionRequest;
-                }
+                return parseSignTransactionRequest(request as SignTransactionRequest);
             case RequestType.SIGN_STAKING:
                 const signStakingRequest = request as SignStakingRequest;
 
@@ -1047,76 +856,7 @@ export class RequestParser {
         : RpcRequest | null {
         switch (request.kind) {
             case RequestType.SIGN_TRANSACTION:
-                const signTransactionRequest = request as ParsedSignTransactionRequest;
-
-                // Check if this is a multi-transaction request
-                if (signTransactionRequest.transactions && signTransactionRequest.serializedTransactions) {
-                    // Multi-transaction format with serialized transactions
-                    return {
-                        appName: signTransactionRequest.appName,
-                        sender: signTransactionRequest.sender instanceof Nimiq.Address
-                            ? signTransactionRequest.sender.toUserFriendlyAddress()
-                            : signTransactionRequest.sender.address.toUserFriendlyAddress(),
-                        senderLabel: signTransactionRequest.senderLabel,
-                        recipientLabel: signTransactionRequest.recipientLabel,
-                        stakerLabel: signTransactionRequest.stakerLabel,
-                        transactions: signTransactionRequest.serializedTransactions,
-                        layout: signTransactionRequest.layout,
-                        validatorAddress: signTransactionRequest.validatorAddress,
-                        validatorImageUrl: signTransactionRequest.validatorImageUrl,
-                        fromValidatorAddress: signTransactionRequest.fromValidatorAddress,
-                        fromValidatorImageUrl: signTransactionRequest.fromValidatorImageUrl,
-                    } as SignTransactionRequest;
-                } else if (signTransactionRequest.transactions) {
-                    // Multi-transaction format with transaction data objects
-                    // Cast to any[] to avoid TypeScript union type issues with map
-                    const txArray = signTransactionRequest.transactions as any[];
-                    return {
-                        appName: signTransactionRequest.appName,
-                        sender: signTransactionRequest.sender instanceof Nimiq.Address
-                            ? signTransactionRequest.sender.toUserFriendlyAddress()
-                            : signTransactionRequest.sender.address.toUserFriendlyAddress(),
-                        senderLabel: signTransactionRequest.senderLabel,
-                        recipientLabel: signTransactionRequest.recipientLabel,
-                        transactions: txArray.map((tx: any) => ({
-                            recipient: typeof tx.recipient === 'string'
-                                ? tx.recipient
-                                : tx.recipient.toUserFriendlyAddress(),
-                            recipientType: tx.recipientType,
-                            recipientLabel: tx.recipientLabel,
-                            value: tx.value,
-                            fee: tx.fee,
-                            extraData: tx.data,
-                            flags: tx.flags,
-                            validityStartHeight: tx.validityStartHeight,
-                            senderType: tx.senderType,
-                            senderLabel: tx.senderLabel,
-                        })),
-                        stakerLabel: signTransactionRequest.stakerLabel,
-                        layout: signTransactionRequest.layout,
-                        validatorAddress: signTransactionRequest.validatorAddress,
-                        validatorImageUrl: signTransactionRequest.validatorImageUrl,
-                        fromValidatorAddress: signTransactionRequest.fromValidatorAddress,
-                        fromValidatorImageUrl: signTransactionRequest.fromValidatorImageUrl,
-                    } as SignTransactionRequest;
-                }
-
-                // Single transaction format (backward compatible)
-                return {
-                    appName: signTransactionRequest.appName,
-                    sender: signTransactionRequest.sender instanceof Nimiq.Address
-                        ? signTransactionRequest.sender.toUserFriendlyAddress()
-                        // Note: additional sender information is lost and does not survive reloads, see RequestTypes.ts
-                        : signTransactionRequest.sender.address.toUserFriendlyAddress(),
-                    recipient: signTransactionRequest.recipient.toUserFriendlyAddress(),
-                    recipientType: signTransactionRequest.recipientType,
-                    recipientLabel: signTransactionRequest.recipientLabel,
-                    value: signTransactionRequest.value,
-                    fee: signTransactionRequest.fee,
-                    extraData: signTransactionRequest.data,
-                    flags: signTransactionRequest.flags,
-                    validityStartHeight: signTransactionRequest.validityStartHeight,
-                } as SignTransactionRequest;
+                return rawSignTransactionRequest(request as ParsedSignTransactionRequest);
             case RequestType.SIGN_STAKING:
                 const signStakingRequest = request as ParsedSignStakingRequest;
                 return {

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -192,7 +192,6 @@ export class RequestParser {
                             isStakingRequest: isStakingTransactions, // Flag for SignTransaction.vue
                             validatorAddress: multiTxRequest.validatorAddress,
                             validatorImageUrl: multiTxRequest.validatorImageUrl,
-                            amount: multiTxRequest.amount,
                             layout: multiTxRequest.layout,
                             fromValidatorAddress: multiTxRequest.fromValidatorAddress,
                             fromValidatorImageUrl: multiTxRequest.fromValidatorImageUrl,
@@ -1062,7 +1061,6 @@ export class RequestParser {
                         validatorImageUrl: signTransactionRequest.validatorImageUrl,
                         fromValidatorAddress: signTransactionRequest.fromValidatorAddress,
                         fromValidatorImageUrl: signTransactionRequest.fromValidatorImageUrl,
-                        amount: signTransactionRequest.amount,
                     } as SignTransactionRequest;
                 } else if (signTransactionRequest.transactions) {
                     // Multi-transaction format with transaction data objects
@@ -1094,7 +1092,6 @@ export class RequestParser {
                         validatorImageUrl: signTransactionRequest.validatorImageUrl,
                         fromValidatorAddress: signTransactionRequest.fromValidatorAddress,
                         fromValidatorImageUrl: signTransactionRequest.fromValidatorImageUrl,
-                        amount: signTransactionRequest.amount,
                     } as SignTransactionRequest;
                 }
 

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -70,24 +70,144 @@ export class RequestParser {
             case RequestType.SIGN_TRANSACTION:
                 const signTransactionRequest = request as SignTransactionRequest;
 
-                if (!signTransactionRequest.value) throw new Error('value is required');
-                if (!signTransactionRequest.validityStartHeight) throw new Error('validityStartHeight is required');
+                // Check if it's a multi-transaction request
+                if ('transactions' in signTransactionRequest && signTransactionRequest.transactions) {
+                    // Multi-transaction format
+                    if (signTransactionRequest.transactions.length === 0) {
+                        throw new Error('transactions array must not be empty');
+                    }
 
-                return {
-                    kind: requestType,
-                    appName: signTransactionRequest.appName,
-                    sender: Nimiq.Address.fromString(signTransactionRequest.sender),
-                    recipient: Nimiq.Address.fromString(signTransactionRequest.recipient),
-                    recipientType: signTransactionRequest.recipientType || Nimiq.AccountType.Basic,
-                    recipientLabel: signTransactionRequest.recipientLabel,
-                    value: signTransactionRequest.value,
-                    fee: signTransactionRequest.fee || 0,
-                    data: typeof signTransactionRequest.extraData === 'string'
-                        ? Utf8Tools.stringToUtf8ByteArray(signTransactionRequest.extraData)
-                        : signTransactionRequest.extraData || new Uint8Array(0),
-                    flags: signTransactionRequest.flags || Nimiq.TransactionFlag.None,
-                    validityStartHeight: signTransactionRequest.validityStartHeight,
-                } as ParsedSignTransactionRequest;
+                    const firstTx = signTransactionRequest.transactions[0];
+
+                    // Check if transactions are serialized (Uint8Array[]) or data objects (TransactionData[])
+                    if (firstTx instanceof Uint8Array) {
+                        // Serialized transactions format (like signStaking)
+                        const serializedTransactions = signTransactionRequest.transactions as Uint8Array[];
+
+                        const plainTransactions = serializedTransactions.map((serializedTx) => {
+                            if (!(serializedTx instanceof Uint8Array)) {
+                                throw new Error('All transactions must be of type Uint8Array');
+                            }
+                            return Nimiq.Transaction.fromAny(serializedTx).toPlain();
+                        });
+
+                        // Check if these are staking transactions
+                        const isStakingTransactions = plainTransactions.every((tx) =>
+                            tx.senderType === 'staking' || tx.recipientType === 'staking',
+                        );
+
+                        // For staking transactions, validate constraints (like SignStaking does)
+                        if (isStakingTransactions) {
+                            if (plainTransactions.length < 1 || plainTransactions.length > 3) {
+                                throw new Error('Expected one to three staking transactions to sign');
+                            }
+
+                            for (const transaction of plainTransactions) {
+                                if (!(['staking', 'basic'] as const)
+                                    .every((type) => transaction.senderType === type
+                                        || transaction.recipientType === type)) {
+                                    throw new Error('Either sender or recipient needs to be of type staking, ' +
+                                        'and the other of type basic.');
+                                }
+                            }
+                        }
+
+                        // Use first transaction for compatibility fields
+                        const firstPlainTx = plainTransactions[0];
+
+                        // Convert string account type to enum
+                        const recipientType = firstPlainTx.recipientType === 'basic' ? Nimiq.AccountType.Basic
+                            : firstPlainTx.recipientType === 'vesting' ? Nimiq.AccountType.Vesting
+                            : firstPlainTx.recipientType === 'htlc' ? Nimiq.AccountType.HTLC
+                            : firstPlainTx.recipientType === 'staking' ? Nimiq.AccountType.Staking
+                            : Nimiq.AccountType.Basic;
+
+                        return {
+                            kind: requestType,
+                            appName: signTransactionRequest.appName,
+                            sender: Nimiq.Address.fromString(signTransactionRequest.sender),
+                            recipient: Nimiq.Address.fromString(firstPlainTx.recipient),
+                            recipientType,
+                            recipientLabel: signTransactionRequest.recipientLabel,
+                            value: firstPlainTx.value,
+                            fee: firstPlainTx.fee,
+                            // For serialized transactions, data field is just for backward compatibility
+                            data: new Uint8Array(0),
+                            flags: firstPlainTx.flags,
+                            validityStartHeight: firstPlainTx.validityStartHeight,
+                            transactions: plainTransactions,
+                            // Store original serialized transactions
+                            // For staking: SignTransaction.vue will re-serialize from PlainTransaction
+                            // For non-staking: SignTransaction.vue will use these bytes directly
+                            serializedTransactions,
+                            senderLabel: signTransactionRequest.senderLabel,
+                            isStakingRequest: isStakingTransactions, // Flag for SignTransaction.vue
+                            // Pass through staking-specific fields (for Keyguard display)
+                            validatorAddress: (signTransactionRequest as any).validatorAddress,
+                            validatorImageUrl: (signTransactionRequest as any).validatorImageUrl,
+                            amount: (signTransactionRequest as any).amount,
+                        } as ParsedSignTransactionRequest;
+                    } else {
+                        // Transaction data objects format
+                        type TransactionData = import('../../client/PublicRequestTypes').TransactionData;
+                        const transactionDataArray = signTransactionRequest.transactions as TransactionData[];
+                        const firstTxData = transactionDataArray[0];
+
+                        return {
+                            kind: requestType,
+                            appName: signTransactionRequest.appName,
+                            sender: Nimiq.Address.fromString(signTransactionRequest.sender),
+                            recipient: Nimiq.Address.fromString(firstTxData.recipient),
+                            recipientType: firstTxData.recipientType || Nimiq.AccountType.Basic,
+                            recipientLabel: signTransactionRequest.recipientLabel,
+                            value: firstTxData.value,
+                            fee: firstTxData.fee || 0,
+                            data: typeof firstTxData.extraData === 'string'
+                                ? Utf8Tools.stringToUtf8ByteArray(firstTxData.extraData)
+                                : firstTxData.extraData || new Uint8Array(0),
+                            flags: firstTxData.flags || Nimiq.TransactionFlag.None,
+                            validityStartHeight: firstTxData.validityStartHeight,
+                            transactions: transactionDataArray.map((tx) => ({
+                                recipient: Nimiq.Address.fromString(tx.recipient),
+                                recipientType: tx.recipientType || Nimiq.AccountType.Basic,
+                                recipientLabel: tx.recipientLabel,
+                                value: tx.value,
+                                fee: tx.fee || 0,
+                                data: typeof tx.extraData === 'string'
+                                    ? Utf8Tools.stringToUtf8ByteArray(tx.extraData)
+                                    : tx.extraData || new Uint8Array(0),
+                                flags: tx.flags || Nimiq.TransactionFlag.None,
+                                validityStartHeight: tx.validityStartHeight,
+                                // Staking-specific fields
+                                senderType: tx.senderType,
+                                senderLabel: tx.senderLabel,
+                            })),
+                            senderLabel: signTransactionRequest.senderLabel,
+                        } as ParsedSignTransactionRequest;
+                    }
+                } else {
+                    // Single transaction format (backward compatible)
+                    type SingleRequest = import('../../client/PublicRequestTypes').SignTransactionRequestSingle;
+                    const singleRequest = signTransactionRequest as SingleRequest;
+                    if (!singleRequest.value) throw new Error('value is required');
+                    if (!singleRequest.validityStartHeight) throw new Error('validityStartHeight is required');
+
+                    return {
+                        kind: requestType,
+                        appName: singleRequest.appName,
+                        sender: Nimiq.Address.fromString(singleRequest.sender),
+                        recipient: Nimiq.Address.fromString(singleRequest.recipient),
+                        recipientType: singleRequest.recipientType || Nimiq.AccountType.Basic,
+                        recipientLabel: singleRequest.recipientLabel,
+                        value: singleRequest.value,
+                        fee: singleRequest.fee || 0,
+                        data: typeof singleRequest.extraData === 'string'
+                            ? Utf8Tools.stringToUtf8ByteArray(singleRequest.extraData)
+                            : singleRequest.extraData || new Uint8Array(0),
+                        flags: singleRequest.flags || Nimiq.TransactionFlag.None,
+                        validityStartHeight: singleRequest.validityStartHeight,
+                    } as ParsedSignTransactionRequest;
+                }
             case RequestType.SIGN_STAKING:
                 const signStakingRequest = request as SignStakingRequest;
 
@@ -102,8 +222,8 @@ export class RequestParser {
                     return Nimiq.Transaction.fromAny(serializedTransaction).toPlain();
                 });
 
-                if (transactions.length !== 1 && transactions.length !== 2) {
-                    throw new Error('Expected one or two staking transactions to sign');
+                if (transactions.length < 1 || transactions.length > 3) {
+                    throw new Error('Expected one to three staking transactions to sign');
                 }
 
                 for (const transaction of transactions) {
@@ -875,6 +995,48 @@ export class RequestParser {
         switch (request.kind) {
             case RequestType.SIGN_TRANSACTION:
                 const signTransactionRequest = request as ParsedSignTransactionRequest;
+
+                // Check if this is a multi-transaction request
+                if (signTransactionRequest.transactions && signTransactionRequest.serializedTransactions) {
+                    // Multi-transaction format with serialized transactions
+                    return {
+                        appName: signTransactionRequest.appName,
+                        sender: signTransactionRequest.sender instanceof Nimiq.Address
+                            ? signTransactionRequest.sender.toUserFriendlyAddress()
+                            : signTransactionRequest.sender.address.toUserFriendlyAddress(),
+                        senderLabel: signTransactionRequest.senderLabel,
+                        recipientLabel: signTransactionRequest.recipientLabel,
+                        transactions: signTransactionRequest.serializedTransactions,
+                    } as SignTransactionRequest;
+                } else if (signTransactionRequest.transactions) {
+                    // Multi-transaction format with transaction data objects
+                    // Cast to any[] to avoid TypeScript union type issues with map
+                    const txArray = signTransactionRequest.transactions as any[];
+                    return {
+                        appName: signTransactionRequest.appName,
+                        sender: signTransactionRequest.sender instanceof Nimiq.Address
+                            ? signTransactionRequest.sender.toUserFriendlyAddress()
+                            : signTransactionRequest.sender.address.toUserFriendlyAddress(),
+                        senderLabel: signTransactionRequest.senderLabel,
+                        recipientLabel: signTransactionRequest.recipientLabel,
+                        transactions: txArray.map((tx: any) => ({
+                            recipient: typeof tx.recipient === 'string'
+                                ? tx.recipient
+                                : tx.recipient.toUserFriendlyAddress(),
+                            recipientType: tx.recipientType,
+                            recipientLabel: tx.recipientLabel,
+                            value: tx.value,
+                            fee: tx.fee,
+                            extraData: tx.data,
+                            flags: tx.flags,
+                            validityStartHeight: tx.validityStartHeight,
+                            senderType: tx.senderType,
+                            senderLabel: tx.senderLabel,
+                        })),
+                    } as SignTransactionRequest;
+                }
+
+                // Single transaction format (backward compatible)
                 return {
                     appName: signTransactionRequest.appName,
                     sender: signTransactionRequest.sender instanceof Nimiq.Address

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -192,6 +192,7 @@ export class RequestParser {
                             // For non-staking: SignTransaction.vue will use these bytes directly
                             serializedTransactions,
                             senderLabel: signTransactionRequest.senderLabel,
+                            stakerLabel: multiTxRequest.stakerLabel,
                             isStakingRequest: isStakingTransactions, // Flag for SignTransaction.vue
                             validatorAddress: multiTxRequest.validatorAddress,
                             validatorImageUrl: multiTxRequest.validatorImageUrl,
@@ -1058,6 +1059,7 @@ export class RequestParser {
                             : signTransactionRequest.sender.address.toUserFriendlyAddress(),
                         senderLabel: signTransactionRequest.senderLabel,
                         recipientLabel: signTransactionRequest.recipientLabel,
+                        stakerLabel: signTransactionRequest.stakerLabel,
                         transactions: signTransactionRequest.serializedTransactions,
                         layout: signTransactionRequest.layout,
                         validatorAddress: signTransactionRequest.validatorAddress,
@@ -1090,6 +1092,7 @@ export class RequestParser {
                             senderType: tx.senderType,
                             senderLabel: tx.senderLabel,
                         })),
+                        stakerLabel: signTransactionRequest.stakerLabel,
                         layout: signTransactionRequest.layout,
                         validatorAddress: signTransactionRequest.validatorAddress,
                         validatorImageUrl: signTransactionRequest.validatorImageUrl,

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -149,20 +149,23 @@ export class RequestParser {
                             }
                             const firstData = plainTransactions[0].data as { type?: string } | undefined;
                             const secondData = plainTransactions[1].data as { type?: string } | undefined;
+                            const thirdSenderData = plainTransactions[2]
+                                .senderData as { type?: string } | undefined;
                             if (firstData?.type !== 'set-active-stake'
-                                || secondData?.type !== 'retire-stake') {
+                                || secondData?.type !== 'retire-stake'
+                                || thirdSenderData?.type !== 'remove-stake') {
                                 throw new Error(
                                     'unstaking transactions must be set-active-stake, retire-stake, '
                                     + 'remove-stake (in order)',
                                 );
                             }
-                            // The third tx is `remove-stake`, an OUTGOING-staking tx whose recipient
-                            // is the user's basic wallet — its data has no parseable `type`.
-                            if (plainTransactions[2].senderType !== 'staking'
-                                || plainTransactions[2].recipientType !== 'basic') {
+                            // Bind all three transactions to the same staker so a caller can't
+                            // redirect the unbonded NIM to an attacker by setting tx2.recipient
+                            // to an arbitrary address while keeping benign labels.
+                            if (plainTransactions[0].sender !== plainTransactions[1].sender
+                                || plainTransactions[2].recipient !== plainTransactions[0].sender) {
                                 throw new Error(
-                                    'third unstaking transaction must be remove-stake '
-                                    + '(staking → basic)',
+                                    'unstaking transactions must be bound to the same staker',
                                 );
                             }
                             if (!multiTxRequest.validatorAddress) {

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -137,6 +137,12 @@ export class RequestParser {
                                     + 'set-active-stake followed by update-staker',
                                 );
                             }
+                            if (!multiTxRequest.validatorAddress) {
+                                throw new Error('switch-validator requires validatorAddress');
+                            }
+                            if (!multiTxRequest.fromValidatorAddress) {
+                                throw new Error('switch-validator requires fromValidatorAddress');
+                            }
                         } else if (multiTxRequest.layout === 'unstaking') {
                             if (plainTransactions.length !== 3) {
                                 throw new Error('unstaking requires exactly three transactions');

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -1057,6 +1057,12 @@ export class RequestParser {
                         senderLabel: signTransactionRequest.senderLabel,
                         recipientLabel: signTransactionRequest.recipientLabel,
                         transactions: signTransactionRequest.serializedTransactions,
+                        layout: signTransactionRequest.layout,
+                        validatorAddress: signTransactionRequest.validatorAddress,
+                        validatorImageUrl: signTransactionRequest.validatorImageUrl,
+                        fromValidatorAddress: signTransactionRequest.fromValidatorAddress,
+                        fromValidatorImageUrl: signTransactionRequest.fromValidatorImageUrl,
+                        amount: signTransactionRequest.amount,
                     } as SignTransactionRequest;
                 } else if (signTransactionRequest.transactions) {
                     // Multi-transaction format with transaction data objects
@@ -1083,6 +1089,12 @@ export class RequestParser {
                             senderType: tx.senderType,
                             senderLabel: tx.senderLabel,
                         })),
+                        layout: signTransactionRequest.layout,
+                        validatorAddress: signTransactionRequest.validatorAddress,
+                        validatorImageUrl: signTransactionRequest.validatorImageUrl,
+                        fromValidatorAddress: signTransactionRequest.fromValidatorAddress,
+                        fromValidatorImageUrl: signTransactionRequest.fromValidatorImageUrl,
+                        amount: signTransactionRequest.amount,
                     } as SignTransactionRequest;
                 }
 

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -31,24 +31,26 @@ export interface ParsedChooseAddressRequest extends ParsedBasicRequest {
     ui?: number;
 }
 
-export interface ParsedTransactionData {
-    recipient: Nimiq.Address;
-    recipientType: Nimiq.AccountType;
-    recipientLabel?: string;
-    value: number;
-    fee: number;
-    data: Uint8Array;
-    flags: number;
-    validityStartHeight: number;
-    // Optional fields for staking transactions
-    senderType?: Nimiq.AccountType;
-    senderLabel?: string;
+// Note: the Keyguard additionally has 'checkout' and 'cashlink' layouts; those are separate Hub request types (CHECKOUT
+// / CREATE_CASHLINK) and not part of SIGN_TRANSACTION. This also makes the additional check that multiple transactions
+// are only supported for standard, switch-validator and unstaking layouts (SignTransactionApi.js parseRequest) a super-
+// fluous check here, which doesn't hurt though.
+export enum SignTransactionRequestLayout {
+    STANDARD = 'standard',
+    SWITCH_VALIDATOR = 'switch-validator',
+    UNSTAKING = 'unstaking',
 }
 
 export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
-    // The sender object is currently only for internal use in RefundSwapLedger and can not be set in public request.
-    // Note that the object does not get exported to the history state in RpcApi and therefore does not survive reloads.
-    // However, the RefundSwapLedger handler is built in a way that it starts over on reloads to avoid the problem.
+    // Request-level sender address which determines the signer for all transactions. For the legacy single-transaction
+    // public request format, the sender's account type is not part of the request; the parsed transaction is then built
+    // with senderType basic and the actual type (basic, or vesting / HTLC contract) is resolved from the WalletStore in
+    // the views, which build the Keyguard request / Ledger transaction from the parsed transaction's fields plus the
+    // resolved senderType.
+    // The sender object form is currently only for internal use in RefundSwapLedger and can not be set in a public
+    // request. Note that the object does not get exported to the history state in RpcApi and therefore does not
+    // survive reloads. However, the RefundSwapLedger handler is built in a way that it starts over on reloads to
+    // avoid the problem.
     sender: Nimiq.Address | {
         address: Nimiq.Address,
         label?: string,
@@ -57,29 +59,21 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
         signerKeyId: string,
         signerKeyPath: string,
     };
-    // Fields for single transaction (backward compatible)
-    recipient: Nimiq.Address;
-    recipientType: Nimiq.AccountType;
-    recipientLabel?: string;
-    value: number;
-    fee: number;
-    data: Uint8Array;
-    flags: number;
-    validityStartHeight: number; // FIXME To be made optional when hub has its own network
-    // Optional fields for multiple/staking transactions
+    layout: SignTransactionRequestLayout; // also triggers layout-specific validation
+    transactions: Nimiq.Transaction[]; // a legacy single-transaction request is wrapped into a one-element array
+    // For the standard layout, labels are only parsed when a single transaction is requested. For the staking
+    // layouts, senderLabel and recipientLabel name the (from- and to-)validators.
     senderLabel?: string;
-    transactions?: ParsedTransactionData[] | PlainTransaction[];
-    // Store original serialized transactions when they were provided in Uint8Array[] format
-    serializedTransactions?: Uint8Array[];
-    // Flag to indicate if this is a staking request (for special handling)
-    isStakingRequest?: boolean;
-    // Staking-specific fields (passed through to Keyguard for display)
+    recipientLabel?: string;
+    // switch-validator only: labels the user's staking address (senderLabel / recipientLabel name the validators).
     stakerLabel?: string;
-    validatorAddress?: string;
-    validatorImageUrl?: string;
-    layout?: 'switch-validator' | 'unstaking';
-    fromValidatorAddress?: string;
-    fromValidatorImageUrl?: string;
+    // For switch-validator, derived from the signed update-staker transaction's newDelegation. For unstaking, parsed
+    // from the request's required validatorAddress.
+    validatorAddress?: Nimiq.Address;
+    validatorImageUrl?: URL;
+    // switch-validator only
+    fromValidatorAddress?: Nimiq.Address;
+    fromValidatorImageUrl?: URL;
 }
 
 export interface ParsedMultisigInfo {

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -31,6 +31,20 @@ export interface ParsedChooseAddressRequest extends ParsedBasicRequest {
     ui?: number;
 }
 
+export interface ParsedTransactionData {
+    recipient: Nimiq.Address;
+    recipientType: Nimiq.AccountType;
+    recipientLabel?: string;
+    value: number;
+    fee: number;
+    data: Uint8Array;
+    flags: number;
+    validityStartHeight: number;
+    // Optional fields for staking transactions
+    senderType?: Nimiq.AccountType;
+    senderLabel?: string;
+}
+
 export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     // The sender object is currently only for internal use in RefundSwapLedger and can not be set in public request.
     // Note that the object does not get exported to the history state in RpcApi and therefore does not survive reloads.
@@ -43,6 +57,7 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
         signerKeyId: string,
         signerKeyPath: string,
     };
+    // Fields for single transaction (backward compatible)
     recipient: Nimiq.Address;
     recipientType: Nimiq.AccountType;
     recipientLabel?: string;
@@ -51,6 +66,17 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     data: Uint8Array;
     flags: number;
     validityStartHeight: number; // FIXME To be made optional when hub has its own network
+    // Optional fields for multiple/staking transactions
+    senderLabel?: string;
+    transactions?: ParsedTransactionData[] | PlainTransaction[];
+    // Store original serialized transactions when they were provided in Uint8Array[] format
+    serializedTransactions?: Uint8Array[];
+    // Flag to indicate if this is a staking request (for special handling)
+    isStakingRequest?: boolean;
+    // Staking-specific fields (passed through to Keyguard for display)
+    validatorAddress?: string;
+    validatorImageUrl?: string;
+    amount?: number;
 }
 
 export interface ParsedMultisigInfo {

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -77,6 +77,9 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     validatorAddress?: string;
     validatorImageUrl?: string;
     amount?: number;
+    layout?: 'switch-validator';
+    fromValidatorAddress?: string;
+    fromValidatorImageUrl?: string;
 }
 
 export interface ParsedMultisigInfo {
@@ -119,6 +122,11 @@ export interface ParsedSignStakingRequest extends ParsedBasicRequest {
     senderLabel?: string;
     recipientLabel?: string;
     transactions: PlainTransaction[];
+    validatorAddress?: string;
+    fromValidatorAddress?: string;
+    validatorImageUrl?: string;
+    fromValidatorImageUrl?: string;
+    amount?: number;
 }
 
 export type ParsedProtocolSpecificsForCurrency<C extends Currency> =

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -61,12 +61,12 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     };
     layout: SignTransactionRequestLayout; // also triggers layout-specific validation
     transactions: Nimiq.Transaction[]; // a legacy single-transaction request is wrapped into a one-element array
-    // For the standard layout, labels are only parsed when a single transaction is requested. For the staking
-    // layouts, senderLabel and recipientLabel name the (from- and to-)validators.
+    // For the standard layout, labels are only parsed when a single transaction is requested. For switch-validator,
+    // senderLabel and recipientLabel name the (from- and to-)validators. For unstaking, senderLabel names the
+    // validator, while recipientLabel is not parsed: the payout recipient is the user's own address, which
+    // SignTransaction.vue labels from the user's account data.
     senderLabel?: string;
     recipientLabel?: string;
-    // switch-validator only: labels the user's staking address (senderLabel / recipientLabel name the validators).
-    stakerLabel?: string;
     // For switch-validator, derived from the signed update-staker transaction's newDelegation. For unstaking, parsed
     // from the request's required validatorAddress.
     validatorAddress?: Nimiq.Address;

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -77,7 +77,7 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     validatorAddress?: string;
     validatorImageUrl?: string;
     amount?: number;
-    layout?: 'switch-validator';
+    layout?: 'switch-validator' | 'unstaking';
     fromValidatorAddress?: string;
     fromValidatorImageUrl?: string;
 }

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -76,7 +76,6 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     // Staking-specific fields (passed through to Keyguard for display)
     validatorAddress?: string;
     validatorImageUrl?: string;
-    amount?: number;
     layout?: 'switch-validator' | 'unstaking';
     fromValidatorAddress?: string;
     fromValidatorImageUrl?: string;

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -74,6 +74,7 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
     // Flag to indicate if this is a staking request (for special handling)
     isStakingRequest?: boolean;
     // Staking-specific fields (passed through to Keyguard for display)
+    stakerLabel?: string;
     validatorAddress?: string;
     validatorImageUrl?: string;
     layout?: 'switch-validator' | 'unstaking';

--- a/src/lib/SignTransactionRequestParsing.ts
+++ b/src/lib/SignTransactionRequestParsing.ts
@@ -144,7 +144,12 @@ export function parseSignTransactionRequest(request: SignTransactionRequest): Pa
             // sender is the user's own account, for which the label is resolved from the WalletStore in the views. A
             // requested label is not accepted for it, as it would let a caller relabel the user's own account, for
             // example as a well-known account, on the confirmation screens.
-            if ('recipientLabel' in request && transactions.length === 1) {
+            // No label is accepted for the recipient either, if the recipient is the user's own address. This is
+            // the case for outgoing staking transactions, e.g. remove-stake or delete-validator, which are sent
+            // from the staking contract and pay out to the request sender, see the sender binding above. The views
+            // label that side from the user's account data instead.
+            if ('recipientLabel' in request && transactions.length === 1
+                && !transactions[0].recipient.equals(requestSender)) {
                 parsed.recipientLabel = parseLabel(request.recipientLabel, 'recipientLabel');
             }
             break;
@@ -227,7 +232,6 @@ export function parseSignTransactionRequest(request: SignTransactionRequest): Pa
 
             parsed.senderLabel = parseLabel(switchValidatorRequest.senderLabel, 'senderLabel');
             parsed.recipientLabel = parseLabel(switchValidatorRequest.recipientLabel, 'recipientLabel');
-            parsed.stakerLabel = parseLabel(switchValidatorRequest.stakerLabel, 'stakerLabel');
             parsed.fromValidatorAddress = parseAddress(
                 switchValidatorRequest.fromValidatorAddress,
                 'fromValidatorAddress',
@@ -369,7 +373,8 @@ export function parseSignTransactionRequest(request: SignTransactionRequest): Pa
             }
 
             parsed.senderLabel = parseLabel(unstakingRequest.senderLabel, 'senderLabel');
-            parsed.recipientLabel = parseLabel(unstakingRequest.recipientLabel, 'recipientLabel');
+            // No recipientLabel: the payout recipient is the user's own address (enforced above), which a caller
+            // must not be able to relabel; the Hub labels it from the user's account data.
             parsed.validatorAddress = parseAddress(unstakingRequest.validatorAddress, 'validatorAddress', false);
             if (unstakingRequest.validatorImageUrl) {
                 parsed.validatorImageUrl = parseUrl(unstakingRequest.validatorImageUrl, 'validatorImageUrl');
@@ -402,7 +407,6 @@ export function rawSignTransactionRequest(request: ParsedSignTransactionRequest)
         appName: request.appName,
         sender: senderAddress.toUserFriendlyAddress(),
         senderLabel: request.senderLabel,
-        recipientLabel: request.recipientLabel,
         transactions: request.transactions.map((tx) => tx.serialize()),
     };
     switch (request.layout) {
@@ -410,7 +414,7 @@ export function rawSignTransactionRequest(request: ParsedSignTransactionRequest)
             return {
                 ...common,
                 layout: SignTransactionRequestLayout.SWITCH_VALIDATOR,
-                stakerLabel: request.stakerLabel,
+                recipientLabel: request.recipientLabel,
                 // No validatorAddress: it is re-derived from the signed update-staker transaction's newDelegation
                 // on re-parse.
                 validatorImageUrl: request.validatorImageUrl ? request.validatorImageUrl.toString() : undefined,
@@ -423,6 +427,8 @@ export function rawSignTransactionRequest(request: ParsedSignTransactionRequest)
             return {
                 ...common,
                 layout: SignTransactionRequestLayout.UNSTAKING,
+                // No recipientLabel: for the unstaking layout it is not part of the public request, see
+                // SignTransactionRequestUnstaking in PublicRequestTypes.ts.
                 validatorAddress: request.validatorAddress!.toUserFriendlyAddress(),
                 validatorImageUrl: request.validatorImageUrl ? request.validatorImageUrl.toString() : undefined,
             };
@@ -430,6 +436,7 @@ export function rawSignTransactionRequest(request: ParsedSignTransactionRequest)
             return {
                 ...common,
                 layout: SignTransactionRequestLayout.STANDARD,
+                recipientLabel: request.recipientLabel,
             };
         default:
             throw new Error('Invalid selected layout');

--- a/src/lib/SignTransactionRequestParsing.ts
+++ b/src/lib/SignTransactionRequestParsing.ts
@@ -1,0 +1,696 @@
+import { Utf8Tools } from '@nimiq/utils';
+import Config from 'config';
+import { RequestType } from '../../client/PublicRequestTypes';
+import type {
+    SignTransactionRequest,
+    SignTransactionRequestSwitchValidator,
+    SignTransactionRequestUnstaking,
+    TransactionInfo,
+} from '../../client/PublicRequestTypes';
+import { SignTransactionRequestLayout } from './RequestTypes';
+import type { ParsedSignTransactionRequest } from './RequestTypes';
+import { LABEL_MAX_LENGTH } from './Constants';
+
+/**
+ * Parsing of SIGN_TRANSACTION requests and their inverse mapping for the history state.
+ *
+ * This is a close port of the Keyguard's thoroughly reviewed request parsing, and should be kept diffable against it,
+ * check for check (deviations are marked with comments):
+ * - keyguard src/request/sign-transaction/SignTransactionApi.js (parseRequest and its helpers)
+ * - keyguard src/lib/RequestParser.js (parseTransaction, parseLabel, parseAddress, _parseUrl)
+ * The Keyguard re-validates forwarded requests with the original of these checks; for Ledger accounts, which don't
+ * involve the Keyguard, this parsing is the only validation outside the checks and displayed information on the Ledger
+ * itself.
+ *
+ * This module is deliberately kept free of imports of the app graph (RpcApi, router, views), such that unit tests can
+ * import it standalone.
+ */
+
+export function parseSignTransactionRequest(request: SignTransactionRequest): ParsedSignTransactionRequest {
+    // Hub deviation from the Keyguard: the sender address is a request-level field inherited by all transaction
+    // entries, instead of a per-entry field, and there are no keyId / keyPath in the request; the signing account
+    // is instead resolved from the WalletStore via the sender address, which RpcApi verifies to belong to one of
+    // the user's wallets.
+    const requestSender = parseAddress(request.sender, 'sender', false);
+    const layout = parseLayout('layout' in request ? request.layout : undefined);
+
+    let transactions: Nimiq.Transaction[];
+    if ('transactions' in request) {
+        if (!Array.isArray(request.transactions)) {
+            throw new Error('transactions must be an array');
+        }
+        if (request.transactions.length === 0) {
+            throw new Error('transactions array must not be empty');
+        }
+
+        transactions = request.transactions.map(
+            (entry: TransactionInfo | Uint8Array) => {
+                let tx: Nimiq.Transaction;
+                if (entry instanceof Uint8Array) {
+                    try {
+                        tx = Nimiq.Transaction.deserialize(entry);
+                    } catch (error) {
+                        throw new Error(error instanceof Error ? error.message : String(error));
+                    }
+                    // Note that the transaction's sender is checked against the request-level sender in the loop
+                    // over all parsed transactions below.
+                    if (tx.sender.equals(tx.recipient)) {
+                        throw new Error('Sender and recipient must not match');
+                    }
+                    if (tx.networkId !== Config.nimiqNetworkId) {
+                        throw new Error('Wrong transaction network');
+                    }
+                } else {
+                    tx = parseTransaction(entry, requestSender);
+                }
+
+                return tx;
+            },
+        );
+    } else {
+        // Legacy single-transaction request format (backwards compatible). Note that the legacy format does not include
+        // the sender's account type; parseTransaction defaults it to Basic, and the actual type is resolved from the
+        // WalletStore in the views, see ParsedSignTransactionRequest in RequestTypes.ts.
+        transactions = [parseTransaction({
+            recipient: request.recipient,
+            recipientType: request.recipientType,
+            recipientData: request.extraData,
+            value: request.value,
+            fee: request.fee,
+            flags: request.flags,
+            validityStartHeight: request.validityStartHeight,
+        }, requestSender)];
+    }
+
+    // Reject requests where aggregated values would exceed Number.MAX_SAFE_INTEGER, as the conversion to Number for
+    // display would lose precision.
+    const totalValue = transactions.reduce((sum, { value }) => sum + value, BigInt(0));
+    const totalFee = transactions.reduce((sum, { fee }) => sum + fee, BigInt(0));
+    if (totalValue > Number.MAX_SAFE_INTEGER || totalFee > Number.MAX_SAFE_INTEGER) {
+        throw new Error('Total value or fee across transactions exceeds safe integer limit');
+    }
+
+    let previousValidityStartHeight = -1;
+    for (const transaction of transactions) {
+        if (transaction.validityStartHeight < previousValidityStartHeight) {
+            throw new Error('Transactions must be valid in order');
+        }
+        previousValidityStartHeight = transaction.validityStartHeight;
+
+        // Validate the recipient data of incoming staking transactions, and reject those that carry a
+        // user-provided staker / validator signature proof. The Keyguard's transaction.sign() would overwrite it
+        // with a proof from the signing keypair, silently discarding the user's input. If multi-key staker
+        // support is added later, this rejection can be relaxed, if appropriate display of the staker is added to
+        // the UI.
+        if (hasStakerOrValidatorProof(transaction)) {
+            throw new Error('Staking transactions with a user-provided signature proof are not supported');
+        }
+
+        // Hub addition without direct Keyguard counterpart at parse time: check the transactions to be sent from
+        // the request-level sender, from whose account the signing key is resolved (also for contract senders,
+        // for which the signer is the contract's owner) and which RpcApi verifies to belong to one of the user's
+        // wallets. As only a single signing key is resolved per request, transactions from another sender could
+        // not be signed correctly anyway, and binding the transactions to the request sender is what makes
+        // RpcApi's check meaningful for the funds that are actually spent. This is the parse-time analogue of the
+        // Keyguard's signer check in SignTransaction._onConfirm, which can only run once the key is unlocked and
+        // which therefore can only cover basic senders.
+        if (transaction.senderType === Nimiq.AccountType.Staking) {
+            // Outgoing staking transactions, e.g. remove-stake, are sent from the staking contract instead of from
+            // the user's address, and the staker they pay out is determined by their signature proof, which is
+            // created by the signing key. We determine the signer via requestSender and enforce the payout recipient
+            // to match that address as otherwise the signing account would not be represented in the UI.
+            if (!transaction.recipient.equals(requestSender)) {
+                throw new Error('Outgoing staking transactions must pay out to the request sender');
+            }
+        } else if (!transaction.sender.equals(requestSender)) {
+            throw new Error('Transaction sender must match request sender');
+        }
+    }
+
+    const parsed: ParsedSignTransactionRequest = {
+        kind: RequestType.SIGN_TRANSACTION,
+        appName: request.appName,
+        sender: requestSender,
+        layout,
+        transactions,
+    };
+
+    // Parse layout-specific fields.
+    switch (layout) {
+        case SignTransactionRequestLayout.STANDARD: {
+            // Labels are only supported for requests with a single transaction; for multiple transactions, plain
+            // addresses are displayed (same as in the Keyguard).
+            // Deviation from the Keyguard, which also accepts a senderLabel for the standard layout: in the Hub, the
+            // sender is the user's own account, for which the label is resolved from the WalletStore in the views. A
+            // requested label is not accepted for it, as it would let a caller relabel the user's own account, for
+            // example as a well-known account, on the confirmation screens.
+            if ('recipientLabel' in request && transactions.length === 1) {
+                parsed.recipientLabel = parseLabel(request.recipientLabel, 'recipientLabel');
+            }
+            break;
+        }
+        case SignTransactionRequestLayout.SWITCH_VALIDATOR: {
+            const switchValidatorRequest = request as SignTransactionRequestSwitchValidator;
+            if (transactions.length !== 2) {
+                throw new Error('switch-validator layout requires exactly two transactions');
+            }
+
+            const [setActiveStakeTx, updateStakerTx] = transactions;
+
+            // Check transactions to be of the expected format and disallow transactions that don't match the standard
+            // case the simplified SWITCH_VALIDATOR layout represents. For example, the simplified layout relies on the
+            // staker being the user and presents the transactions as operation on the user's own stake, displaying the
+            // fee-paying sender as the staker. That the sender is in fact the user's own address is ensured by the
+            // request-sender binding above together with RpcApi's wallet check, and re-checked by the Keyguard once
+            // the key is unlocked, in SignTransaction._onConfirm.
+
+            // For set-active-stake and update-staker transactions, we don't have to check the following, which are
+            // checked by the Nimiq protocol (statically or on commit) or earlier parsing steps above, or are displayed:
+            // - senderData (must be empty for transaction from basic account; enforced by protocol)
+            // - recipient (must be staking contract for incoming staking transaction; enforced by protocol on commit)
+            // - value (must be zero for signaling transactions; enforced by protocol)
+            // - total fees (must not exceed MAX_SAFE_INTEGER; checked above and displayed)
+            // - validityStartHeight (must be in order and within the typical bounds; checked above and below)
+            // - network id (must match Config.nimiqNetworkId; checked above)
+            // - flags (must be signaling for these transaction types; enforced by protocol)
+            // What must still be checked here: sender, senderType, recipientType, recipientData
+
+            if (!setActiveStakeTx.sender.equals(updateStakerTx.sender)) {
+                // Enforce both transactions to have the same fee-payer. Note that the fee-payer is not necessarily
+                // the same as the staker, because the staker is identified by the staking proof, which can differ
+                // from the tx sender. However, we currently disallow custom staking proofs via the
+                // hasStakerOrValidatorProof check above, such that both staking proofs are generated during signing
+                // from the signing keypair. By this, the same staker is used for both transactions, and it also
+                // matches the transaction senders, as we enforce the senders to be of basic type below and basic
+                // senders to be the request sender above, which the Keyguard's signer check in
+                // SignTransaction._onConfirm enforces to be that same keypair's address.
+                // If we'd allow user-provided staking proofs in the future, we'd need to add a check that the
+                // transaction stakers match and are the same as the transaction senders for the simplified
+                // switch-validator flow.
+                throw new Error('switch-validator transactions must share the same fee-paying sender and staker');
+            }
+
+            if (setActiveStakeTx.senderType !== Nimiq.AccountType.Basic
+                || updateStakerTx.senderType !== Nimiq.AccountType.Basic) {
+                // Enforce basic senders because the switch-validator UI does not show the sender being a contract,
+                // and because the sender can only be checked to be the user's own address for basic senders, which
+                // the staker equality above relies on.
+                throw new Error('switch-validator transaction sender must not be a contract');
+            }
+
+            // recipientType and recipientData
+            // Note that the staking proof on recipientData is already checked via hasStakerOrValidatorProof above.
+            const [setActiveStakeData, updateStakerData] = [setActiveStakeTx, updateStakerTx]
+                .map((tx) => parseIncomingStakingTransactionData(tx));
+            if (!setActiveStakeData || setActiveStakeData.type !== 'set-active-stake'
+                || !updateStakerData || updateStakerData.type !== 'update-staker') {
+                throw new Error('switch-validator transactions must be set-active-stake followed by update-staker');
+            }
+            if (setActiveStakeData.newActiveBalance !== 0) {
+                throw new Error(
+                    'switch-validator set-active-stake must deactivate all stake (newActiveBalance must be 0)',
+                );
+            }
+            if (!updateStakerData.newDelegation) {
+                throw new Error('switch-validator update-staker must include a newDelegation');
+            }
+            if (!updateStakerData.reactivateAllStake) {
+                throw new Error('switch-validator update-staker must have reactivateAllStake set');
+            }
+
+            // Check validityStartHeights to be what is expected from the Wallet.
+            const updateStakerDelay = updateStakerTx.validityStartHeight - setActiveStakeTx.validityStartHeight;
+            if (updateStakerDelay <= Nimiq.Policy.BLOCKS_PER_EPOCH
+                || updateStakerDelay > 2 * Nimiq.Policy.BLOCKS_PER_EPOCH) {
+                throw new Error('switch-validator update-staker must start one to two epochs after set-active-stake');
+            }
+
+            parsed.senderLabel = parseLabel(switchValidatorRequest.senderLabel, 'senderLabel');
+            parsed.recipientLabel = parseLabel(switchValidatorRequest.recipientLabel, 'recipientLabel');
+            parsed.stakerLabel = parseLabel(switchValidatorRequest.stakerLabel, 'stakerLabel');
+            parsed.fromValidatorAddress = parseAddress(
+                switchValidatorRequest.fromValidatorAddress,
+                'fromValidatorAddress',
+                false,
+            );
+            // The signed delegation is authoritative - request data must not influence this.
+            parsed.validatorAddress = parseAddress(
+                updateStakerData.newDelegation,
+                'update-staker newDelegation',
+                false,
+            );
+
+            if (switchValidatorRequest.validatorImageUrl) {
+                parsed.validatorImageUrl = parseUrl(switchValidatorRequest.validatorImageUrl, 'validatorImageUrl');
+            }
+            if (switchValidatorRequest.fromValidatorImageUrl) {
+                parsed.fromValidatorImageUrl = parseUrl(
+                    switchValidatorRequest.fromValidatorImageUrl,
+                    'fromValidatorImageUrl',
+                );
+            }
+            break;
+        }
+        case SignTransactionRequestLayout.UNSTAKING: {
+            const unstakingRequest = request as SignTransactionRequestUnstaking;
+            if (transactions.length !== 3) {
+                throw new Error('unstaking layout requires exactly three transactions');
+            }
+
+            const [setActiveStakeTx, retireStakeTx, removeStakeTx] = transactions;
+
+            // Check transactions to be of the expected format and disallow transactions that don't match the standard
+            // case the simplified UNSTAKING layout represents. For example, the simplified layout relies on the staker
+            // being the user and presents the transactions as operation on the user's own stake and does not display
+            // the fee-paying sender at all. That the sender is in fact the user's own address is ensured by the
+            // request-sender binding above together with RpcApi's wallet check, and re-checked by the Keyguard once
+            // the key is unlocked, in SignTransaction._onConfirm.
+
+            // setActiveStakeTx and retireStakeTx transactions
+            // For setActiveStakeTx and retireStakeTx transactions, we don't have to check the following, which are
+            // checked by the Nimiq protocol (statically or on commit) or earlier parsing steps above, or are displayed:
+            // - senderData (must be empty for transaction from basic account; enforced by protocol)
+            // - recipient (must be staking contract for incoming staking transaction; enforced by protocol on commit)
+            // - value (must be zero for signaling transactions; enforced by protocol)
+            // - total fees (must not exceed MAX_SAFE_INTEGER; checked above and displayed)
+            // - validityStartHeight (must be in order and within the typical bounds; checked above and below)
+            // - network id (must match Config.nimiqNetworkId; checked above)
+            // - flags (must be signaling for these transaction types; enforced by protocol)
+            // What must still be checked here: sender, senderType, recipientType, recipientData
+
+            if (!setActiveStakeTx.sender.equals(retireStakeTx.sender)) {
+                // Enforce the fee-payer to be the same for all three transactions: for incoming staking transactions
+                // setActiveStakeTx and retireStakeTx the fee is paid by the transaction sender, while for the outgoing
+                // removeStakeTx it is paid by the staker from the removed stake. Note that in general the fee-payer is
+                // not necessarily the same as the staker, because the staker is identified by the staking proof.
+                // However, we currently disallow custom staking proofs via the hasStakerOrValidatorProof check above,
+                // such that the staking proofs of setActiveStakeTx and retireStakeTx are generated during signing from
+                // the signing keypair, as is removeStakeTx's signature proof, which identifies its staker. By this,
+                // the same staker is used for all three transactions, and it also matches the transaction senders, as
+                // we enforce the senders to be of basic type below and basic senders to be the request sender above,
+                // which the Keyguard's signer check in SignTransaction._onConfirm enforces to be that same keypair's
+                // address.
+                // If we'd allow user-provided staking proofs in the future, we'd need to add a check that the
+                // transaction stakers match and are the same as the transaction senders for the simplified unstaking
+                // flow.
+                throw new Error('unstaking transactions must share the same fee-paying sender and staker');
+            }
+
+            if (setActiveStakeTx.senderType !== Nimiq.AccountType.Basic
+                || retireStakeTx.senderType !== Nimiq.AccountType.Basic) {
+                // Enforce basic senders because the unstaking UI does not show the sender being a contract, and
+                // because the sender can only be checked to be the user's own address for basic senders, which the
+                // staker equality above and the payout address check below rely on.
+                throw new Error('unstaking transaction sender must not be a contract');
+            }
+
+            // recipientType and recipientData
+            // Note that the staking proof on recipientData is already checked via hasStakerOrValidatorProof above and
+            // the set-active-stake newActiveBalance is shown in the UI.
+            const [setActiveStakeData, retireStakeData] = [setActiveStakeTx, retireStakeTx]
+                .map((tx) => parseIncomingStakingTransactionData(tx));
+            if (!setActiveStakeData || setActiveStakeData.type !== 'set-active-stake'
+                || !retireStakeData || retireStakeData.type !== 'retire-stake') {
+                throw new Error(
+                    // remove-stake is checked below
+                    'unstaking transactions must be set-active-stake, retire-stake, remove-stake (in order)',
+                );
+            }
+            if (retireStakeData.retireStake > removeStakeTx.value + removeStakeTx.fee) {
+                throw new Error('unstaking must not retire more than is being paid out');
+            }
+
+            // removeStake transaction
+            // For removeStake, we don't have to check the following, which are checked by the Nimiq protocol
+            // (statically or on commit) or earlier parsing steps above, or are displayed:
+            // - sender (must be staking contract for outgoing staking transaction; enforced by protocol on commit)
+            // - value (value + fee must be >= retired amount; checked above and displayed)
+            // - total fees (must not exceed MAX_SAFE_INTEGER; checked above and displayed)
+            // - validityStartHeight (must be in order and within the typical bounds; checked above and below)
+            // - network id (must match Config.nimiqNetworkId; checked above)
+            // - flags (must be none for transaction to basic account; enforced by protocol)
+            // What must still be checked here: senderType, senderData, recipient, recipientType, recipientData
+
+            // senderType and senderData
+            const removeStakeData = parseOutgoingStakingTransactionData(removeStakeTx);
+            if (!removeStakeData || removeStakeData.type !== 'remove-stake') {
+                throw new Error(
+                    // set-active-stake and retire-stake are checked above
+                    'unstaking transactions must be set-active-stake, retire-stake, remove-stake (in order)',
+                );
+            }
+
+            if (!removeStakeTx.recipient.equals(setActiveStakeTx.sender)) {
+                // Enforce the payout address of the unstaked funds to be the same as the fee payer and the staking
+                // address. This way, the transactions are easier for the user to interpret, and it is clear where the
+                // funds are coming from and where they are going to. Note that this check is also what ties the payout
+                // to the user's own address, preventing the unstaked NIM from being sent to an attacker via
+                // benign-looking labels.
+                throw new Error('unstaking transactions must payout to the fee payer and staker address');
+            }
+
+            if (removeStakeTx.recipientType !== Nimiq.AccountType.Basic) {
+                throw new Error('unstaking transactions must not payout to a contract');
+            }
+
+            if (removeStakeTx.data.length) {
+                // Disallow recipient data because we don't display it in the simplified unstaking flow.
+                throw new Error('unstaking transactions must not have recipient data');
+            }
+
+            // Check validityStartHeights to be what is expected from the Wallet.
+            const retireStakeDelay = retireStakeTx.validityStartHeight - setActiveStakeTx.validityStartHeight;
+            if (retireStakeDelay <= Nimiq.Policy.BLOCKS_PER_EPOCH
+                || retireStakeDelay > 2 * Nimiq.Policy.BLOCKS_PER_EPOCH) {
+                throw new Error('unstaking retire-stake must start one to two epochs after set-active-stake');
+            }
+            if (removeStakeTx.validityStartHeight !== retireStakeTx.validityStartHeight + 1) {
+                throw new Error('unstaking remove-stake must start one block after retire-stake');
+            }
+
+            parsed.senderLabel = parseLabel(unstakingRequest.senderLabel, 'senderLabel');
+            parsed.recipientLabel = parseLabel(unstakingRequest.recipientLabel, 'recipientLabel');
+            parsed.validatorAddress = parseAddress(unstakingRequest.validatorAddress, 'validatorAddress', false);
+            if (unstakingRequest.validatorImageUrl) {
+                parsed.validatorImageUrl = parseUrl(unstakingRequest.validatorImageUrl, 'validatorImageUrl');
+            }
+            break;
+        }
+        default:
+            // Not expected to be reachable, as the layout was parsed by parseLayout, but makes sure that a layout
+            // added in the future can not skip the layout-specific checks.
+            throw new Error('Invalid selected layout');
+    }
+
+    return parsed;
+}
+
+/**
+ * Inverse of parseSignTransactionRequest, for exporting the parsed request to the history state in RpcApi._exportState,
+ * whose output is re-parsed by RequestParser.parse on reload.
+ *
+ * The request is always exported in the transactions-array byte format, also when it arrived in the legacy
+ * single-transaction field format. Only values that survive both persistence channels (structured clone into
+ * history.state, and JSONUtils' base64 encoding into sessionStorage) may be exported: plain strings, numbers and
+ * Uint8Array - no class instances like Nimiq.Address or URL.
+ */
+export function rawSignTransactionRequest(request: ParsedSignTransactionRequest): SignTransactionRequest {
+    const senderAddress = request.sender instanceof Nimiq.Address ? request.sender : request.sender.address;
+    // Note: the additional information of the internal sender object form (RefundSwapLedger) is intentionally
+    // lost and does not survive reloads, see ParsedSignTransactionRequest in RequestTypes.ts.
+    const common = {
+        appName: request.appName,
+        sender: senderAddress.toUserFriendlyAddress(),
+        senderLabel: request.senderLabel,
+        recipientLabel: request.recipientLabel,
+        transactions: request.transactions.map((tx) => tx.serialize()),
+    };
+    switch (request.layout) {
+        case SignTransactionRequestLayout.SWITCH_VALIDATOR:
+            return {
+                ...common,
+                layout: SignTransactionRequestLayout.SWITCH_VALIDATOR,
+                stakerLabel: request.stakerLabel,
+                // No validatorAddress: it is re-derived from the signed update-staker transaction's newDelegation
+                // on re-parse.
+                validatorImageUrl: request.validatorImageUrl ? request.validatorImageUrl.toString() : undefined,
+                fromValidatorAddress: request.fromValidatorAddress!.toUserFriendlyAddress(),
+                fromValidatorImageUrl: request.fromValidatorImageUrl
+                    ? request.fromValidatorImageUrl.toString()
+                    : undefined,
+            };
+        case SignTransactionRequestLayout.UNSTAKING:
+            return {
+                ...common,
+                layout: SignTransactionRequestLayout.UNSTAKING,
+                validatorAddress: request.validatorAddress!.toUserFriendlyAddress(),
+                validatorImageUrl: request.validatorImageUrl ? request.validatorImageUrl.toString() : undefined,
+            };
+        case SignTransactionRequestLayout.STANDARD:
+            return {
+                ...common,
+                layout: SignTransactionRequestLayout.STANDARD,
+            };
+        default:
+            throw new Error('Invalid selected layout');
+    }
+}
+
+/**
+ * Hub-only, no Keyguard equivalent: applies the sender's account type resolved from the WalletStore to a request in
+ * the legacy single-transaction object format. This legacy format can not specify the sender type, such that its parsed
+ * transaction defaults to a basic sender as placeholder (see parseSignTransactionRequest), which this method replaces.
+ */
+export function patchLegacyRequestSenderType(
+    request: ParsedSignTransactionRequest,
+    actualSenderType: Nimiq.AccountType,
+): void {
+    // Only the standard layout with a single transaction can originate from the legacy format. The transactions of
+    // all other requests are forwarded exactly as they were parsed.
+    if (request.layout !== SignTransactionRequestLayout.STANDARD || request.transactions.length !== 1) return;
+    const [transaction] = request.transactions;
+    if (transaction.senderType !== Nimiq.AccountType.Basic // Preserve explicitly specified non-basic sender types.
+        || actualSenderType === Nimiq.AccountType.Basic // Nothing to do if the actualSenderType is actually basic.
+    ) return;
+
+    // Note that the Nimiq.Transaction constructor automatically updates the correct contract creation
+    // address for contract creations, overwriting the passed recipient in that case.
+    request.transactions[0] = new Nimiq.Transaction(
+        transaction.sender, actualSenderType, transaction.senderData,
+        transaction.recipient, transaction.recipientType, transaction.data,
+        transaction.value, transaction.fee,
+        transaction.flags, transaction.validityStartHeight, transaction.networkId,
+    );
+}
+
+/**
+ * Checks that the given layout is valid.
+ * Port of the Keyguard's SignTransactionApi.parseLayout.
+ */
+function parseLayout(layout: unknown): SignTransactionRequestLayout {
+    if (!layout) {
+        return SignTransactionRequestLayout.STANDARD;
+    }
+    if (!(Object.values(SignTransactionRequestLayout) as unknown[]).includes(layout)) {
+        throw new Error('Invalid selected layout');
+    }
+    return layout as SignTransactionRequestLayout;
+}
+
+/**
+ * Port of the Keyguard's RequestParser.parseTransaction, building a Nimiq.Transaction from a plain transaction
+ * info object, with the following deviations:
+ * - Entries don't include a sender address; the request-level sender is inherited (passed in as parameter).
+ * - fee is optional in the Hub's public API and defaults to 0.
+ * - The flags are additionally checked to be a single known flag
+ * - contract address of contract creations is not re-derived after building the transaction, see below
+ */
+function parseTransaction(object: TransactionInfo, sender: Nimiq.Address): Nimiq.Transaction {
+    if (!object || typeof object !== 'object') {
+        throw new Error('Transaction info must be an object');
+    }
+
+    const accountTypes = new Set([
+        Nimiq.AccountType.Basic,
+        Nimiq.AccountType.Vesting,
+        Nimiq.AccountType.HTLC,
+        Nimiq.AccountType.Staking,
+    ]);
+
+    const senderType = object.senderType || Nimiq.AccountType.Basic;
+    if (!accountTypes.has(senderType)) {
+        throw new Error('Invalid sender type');
+    }
+
+    const senderData = typeof object.senderData === 'string'
+        ? Utf8Tools.stringToUtf8ByteArray(object.senderData)
+        : object.senderData || new Uint8Array(0);
+
+    const recipient = parseAddress(object.recipient, 'recipient', true);
+    const recipientType = object.recipientType || Nimiq.AccountType.Basic;
+    if (!accountTypes.has(recipientType)) {
+        throw new Error('Invalid recipient type');
+    }
+
+    const recipientData = typeof object.recipientData === 'string'
+        ? Utf8Tools.stringToUtf8ByteArray(object.recipientData)
+        : object.recipientData || new Uint8Array(0);
+
+    const flags = object.flags || Nimiq.TransactionFlag.None;
+
+    // Addition without a Keyguard counterpart: check the flags to be exactly one of the known flag values. The Keyguard
+    // only compares them via === in the contract creation checks below, which lets flag combinations slip through while
+    // Nimiq.Transaction turns them into a contract creation nonetheless.
+    if (![Nimiq.TransactionFlag.None, Nimiq.TransactionFlag.ContractCreation, Nimiq.TransactionFlag.Signaling]
+        .includes(flags)) {
+        throw new Error('Combined flags are not supported for transaction entries');
+    }
+
+    if (
+        flags === Nimiq.TransactionFlag.None
+        && recipientType !== Nimiq.AccountType.Staking
+        && recipientData.byteLength > 64
+    ) {
+        throw new Error('Data must not exceed 64 bytes');
+    }
+    if (
+        flags === Nimiq.TransactionFlag.ContractCreation
+        && recipientData.byteLength !== 82 // HTLC
+        && recipientData.byteLength !== 28 // Vesting
+        && recipientData.byteLength !== 44 // Vesting
+        && recipientData.byteLength !== 52 // Vesting
+    ) {
+        throw new Error(
+            'Contract creation data must be 82 bytes for HTLC and 28, 44, or 52 bytes for vesting contracts',
+        );
+    }
+    if (flags === Nimiq.TransactionFlag.ContractCreation && recipient !== 'CONTRACT_CREATION') {
+        throw new Error('Transaction recipient must be "CONTRACT_CREATION" when creating contracts');
+    }
+    // Addition without a Keyguard counterpart: reject the pseudo recipient without the contract creation flag, for
+    // which the Keyguard is only covered by re-deriving the contract address for the pseudo recipient regardless of
+    // the flags, which does not apply here (see below). Without this check, the placeholder address passed to
+    // Nimiq.Transaction for the pseudo recipient would end up in the transaction as an actual recipient, sending the
+    // funds to the burn address.
+    if (recipient === 'CONTRACT_CREATION' && flags !== Nimiq.TransactionFlag.ContractCreation) {
+        throw new Error('Transaction recipient can only be "CONTRACT_CREATION" when creating contracts');
+    }
+
+    try {
+        // Deviation from the Keyguard, which builds contract creations with a zero placeholder recipient and then
+        // recreates the transaction with the contract address derived as the transaction's hash: Nimiq.Transaction
+        // already derives the contract address itself and replaces whatever recipient is passed with it.
+        const tx = new Nimiq.Transaction(
+            sender,
+            senderType,
+            senderData,
+            recipient !== 'CONTRACT_CREATION' ? recipient : new Nimiq.Address(new Uint8Array(20)),
+            recipientType,
+            recipientData,
+            BigInt(object.value),
+            BigInt(object.fee || 0),
+            flags,
+            object.validityStartHeight,
+            Config.nimiqNetworkId,
+        );
+
+        if (tx.sender.equals(tx.recipient)) {
+            throw new Error('Sender and recipient must not match');
+        }
+
+        return tx;
+    } catch (error) {
+        throw new Error(error instanceof Error ? error.message : String(error));
+    }
+}
+
+/**
+ * Returns the parsed recipient data for an incoming staking transaction, or `undefined` if the transaction isn't
+ * an incoming staking transaction.
+ * Port of the Keyguard's SignTransactionApi._parseIncomingStakingTransactionData.
+ */
+function parseIncomingStakingTransactionData(tx: Nimiq.Transaction)
+    : Nimiq.PlainTransactionRecipientData | undefined {
+    if (tx.recipientType !== Nimiq.AccountType.Staking) return undefined;
+    try {
+        return Nimiq.StakingContract.dataToPlain(tx.data);
+    } catch (e) {
+        throw new Error('Invalid incoming staking transaction data');
+    }
+}
+
+/**
+ * Returns the parsed sender data for an outgoing staking transaction, or `undefined` if the transaction isn't an
+ * outgoing staking transaction.
+ * Port of the Keyguard's SignTransactionApi._parseOutgoingStakingTransactionData.
+ */
+function parseOutgoingStakingTransactionData(tx: Nimiq.Transaction): Nimiq.PlainTransactionSenderData | undefined {
+    if (tx.senderType !== Nimiq.AccountType.Staking) return undefined;
+    try {
+        return tx.toPlain().senderData;
+    } catch (e) {
+        throw new Error('Invalid transaction or transaction data');
+    }
+}
+
+/**
+ * Detects whether an incoming staking transaction carries a filled-in staker / validator SignatureProof at the end of
+ * its recipient data. TransactionBuilder produces these transactions with a zero-filled placeholder proof that
+ * `transaction.sign()` later fills in using the outer keypair. If the trailing bytes already contain a non-zero proof,
+ * we treat it as user-provided.
+ *
+ * Operations without an embedded proof (outgoing staking, `add-stake`) return false.
+ * Throws for incoming staking transactions with invalid recipient data.
+ *
+ * Port of the Keyguard's SignTransactionApi._hasStakerOrValidatorProof.
+ */
+function hasStakerOrValidatorProof(tx: Nimiq.Transaction): boolean {
+    const data = parseIncomingStakingTransactionData(tx); // validate and throw on invalid data
+    if (!data) return false; // not an incoming staking transaction
+    if (data.type === 'add-stake') return false; // add-stake has no embedded staking proof.
+
+    const recipientData = tx.data; // tx.data is a getter; cache its result
+    if (recipientData.length < Nimiq.SignatureProof.SINGLE_SIG_SIZE) return false;
+
+    const proofStart = recipientData.length - Nimiq.SignatureProof.SINGLE_SIG_SIZE;
+    for (let i = proofStart; i < recipientData.length; i++) {
+        if (recipientData[i] !== 0) return true;
+    }
+    return false;
+}
+
+/**
+ * Port of the Keyguard's RequestParser.parseLabel, without its allowEmpty parameter, as all Hub labels are optional.
+ */
+function parseLabel(label: unknown, parameterName: string = 'Label'): string | undefined {
+    if (!label) {
+        return undefined;
+    }
+    if (typeof label !== 'string') {
+        throw new Error(`${parameterName} must be a string`);
+    }
+    if (Utf8Tools.stringToUtf8ByteArray(label).byteLength > LABEL_MAX_LENGTH) {
+        throw new Error(`${parameterName} must not exceed ${LABEL_MAX_LENGTH} bytes`);
+    }
+    if (/[\x00-\x1F\x7F]/.test(label)) {
+        throw new Error('Label cannot contain control characters');
+    }
+    return label;
+}
+
+/**
+ * Port of the Keyguard's RequestParser.parseAddress, using Nimiq.Address.fromAny as is the convention in RequestParser,
+ * instead of the Nimiq.Address constructor, which converts array-likes into an arbitrary address instead of rejecting
+ * them, for example `{ length: 20 }` into the zero address.
+ */
+function parseAddress<T extends boolean>(address: unknown, name: string, allowContractCreation: T)
+    : Nimiq.Address | (T extends true ? 'CONTRACT_CREATION' : never) {
+    if (allowContractCreation && address === 'CONTRACT_CREATION') {
+        return 'CONTRACT_CREATION' as (T extends true ? 'CONTRACT_CREATION' : never);
+    }
+
+    try {
+        return Nimiq.Address.fromAny(address as Nimiq.Address | string | Uint8Array);
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`${name} must be a valid Nimiq address (${errorMessage})`);
+    }
+}
+
+/**
+ * Port of the Keyguard's RequestParser._parseUrl, with an added try/catch around the URL constructor for a clean error
+ * message.
+ */
+function parseUrl(url: string, parameterName: string): URL {
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(url);
+    } catch (e) {
+        throw new Error(`${parameterName} must be a valid URL`);
+    }
+    const whitelistedProtocols = ['https:', 'http:', 'chrome-extension:', 'moz-extension:', 'data:'];
+    if (!whitelistedProtocols.includes(parsedUrl.protocol)) {
+        throw new Error(`${parameterName} protocol must be one of: ${whitelistedProtocols.join(', ')}`);
+    }
+    return parsedUrl;
+}

--- a/src/views/CashlinkCreate.vue
+++ b/src/views/CashlinkCreate.vue
@@ -435,7 +435,6 @@ class CashlinkCreate extends Vue {
                     senderLabel: this.accountOrContractInfo!.label,
                     recipient: fundingDetails.recipient.serialize(),
                     recipientType: Nimiq.AccountType.Basic as any, // TODO: Update with new Keyguard Client
-                    fee: this.fee,
                     validityStartHeight,
                 });
                 staticStore.keyguardRequest = request;

--- a/src/views/CashlinkManage.vue
+++ b/src/views/CashlinkManage.vue
@@ -197,8 +197,12 @@ export default class CashlinkManage extends Vue {
             // Store cashlink in database first to be safe when browser crashes during sending
             await CashlinkStore.Instance.put(this.retrievedCashlink);
 
+            // Cashlink layout only supports single transactions, safe to cast
+            const singleTxRequest = this.keyguardRequest as Exclude<
+                KeyguardClient.SignTransactionRequest, { transactions: any }
+            >;
             transactionToSend = transactionToSend || network.createTx({
-                ...this.keyguardRequest,
+                ...singleTxRequest,
                 signerPubKey: this.keyguardResult.publicKey,
                 signature: this.keyguardResult.signature,
             });

--- a/src/views/RefundSwap.vue
+++ b/src/views/RefundSwap.vue
@@ -166,7 +166,7 @@ export default class RefundSwap extends BitcoinSyncBaseView {
             client.signBtcTransaction(request);
         } else {
             // Polygon request
-            client.signPolygonTransaction(request);
+            client.signPolygonTransaction(request as KeyguardSignPolygonTransactionRequest);
         }
     }
 }

--- a/src/views/RefundSwapLedger.vue
+++ b/src/views/RefundSwapLedger.vue
@@ -269,7 +269,8 @@ export default class RefundSwapLedger extends RefundSwap {
             ] as const);
 
             const { walletId: accountId } = this.request as ParsedRefundSwapRequest;
-            const { appName, inputs: [htlcInput], recipientOutput: output } = request;
+            const btcRequest = request as KeyguardSignBtcTransactionRequest;
+            const { appName, inputs: [htlcInput], recipientOutput: output } = btcRequest;
 
             // Type guard to ensure inputs have a witnessScript
             if (htlcInput.type !== BitcoinTransactionInputType.HTLC_REFUND) {

--- a/src/views/RefundSwapLedger.vue
+++ b/src/views/RefundSwapLedger.vue
@@ -102,8 +102,9 @@ export default class RefundSwapLedger extends RefundSwap {
             this.state = this.State.SYNCING; // proxy transaction history is synced in LedgerSwapProxy.createForRefund
 
             const request = this.request as ParsedSignTransactionRequest;
-            const { sender: senderInfo, recipient, value, fee, data, validityStartHeight } = request;
-            const sender = senderInfo instanceof Nimiq.Address ? senderInfo : senderInfo.address;
+            const [transaction] = request.transactions;
+            const { recipient, value, fee, validityStartHeight } = transaction;
+            const sender = request.sender instanceof Nimiq.Address ? request.sender : request.sender.address;
             // existence guaranteed as already checked previously in RefundSwap
             const ledgerAccount = this.findWalletByAddress(recipient.toUserFriendlyAddress(), true)!;
 

--- a/src/views/SignStaking.vue
+++ b/src/views/SignStaking.vue
@@ -23,7 +23,6 @@ export default class SignStaking extends Vue {
         let recipientLabel = this.request.recipientLabel;
 
         const finalTransaction = this.request.transactions[this.request.transactions.length - 1];
-        console.log(finalTransaction);
 
         const signerSide = finalTransaction.senderType === 'basic' ? 'sender' as const : 'recipient' as const;
         const signerAddress = finalTransaction[signerSide];
@@ -39,7 +38,13 @@ export default class SignStaking extends Vue {
             senderLabel = this.request.senderLabel || this.$t('Staking Contract') as string;
             recipientLabel = signer.label;
         } else {
-            senderLabel = signer.label;
+            // update-staker carries the previous validator's name as senderLabel so Keyguard
+            // can render "from → to". Other staking flows have no such label, so fall back to
+            // the signer's account label (the user).
+            const isUpdateStaker = finalTransaction.data.type === 'update-staker';
+            senderLabel = isUpdateStaker && this.request.senderLabel
+                ? this.request.senderLabel
+                : signer.label;
             recipientLabel = this.request.recipientLabel || this.$t('Staking Contract') as string;
         }
 

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -2,11 +2,17 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { ParsedSignTransactionRequest } from '../lib/RequestTypes';
+import { ParsedSignTransactionRequest, SignTransactionRequestLayout } from '../lib/RequestTypes';
+import { patchLegacyRequestSenderType } from '../lib/SignTransactionRequestParsing';
 import KeyguardClient from '@nimiq/keyguard-client';
 import staticStore, { Static } from '../lib/StaticStore';
 import { WalletInfo } from '../lib/WalletInfo';
 import { Getter } from 'vuex-class';
+
+type CommonRequestProperties = KeyguardClient.SimpleRequest & { keyPath: string }
+    & Pick<KeyguardClient.SignTransactionRequestUnstaking, 'transactions'>;
+type CommonStakingRequestProperties = CommonRequestProperties
+    & Pick<KeyguardClient.SignTransactionRequestUnstaking, 'senderLabel' | 'validatorImageUrl'>;
 
 @Component
 export default class SignTransaction extends Vue {
@@ -16,234 +22,92 @@ export default class SignTransaction extends Vue {
     public created() {
         // Forward user through Hub to Keyguard
 
-        let senderAddress: Nimiq.Address;
-        let senderLabel: string | undefined;
-        let senderType: Nimiq.AccountType | undefined;
-        let keyId: string;
-        let keyPath: string;
-        let keyLabel: string | undefined;
-        let recipientLabel: string | undefined = this.request.recipientLabel;
-
-        // For staking transactions, determine signer by last transaction (like SignStaking does)
-        if (this.request.isStakingRequest && this.request.transactions && this.request.transactions.length > 0) {
-            const finalTransaction = this.request.transactions[this.request.transactions.length - 1];
-            const signerSide = (finalTransaction as any).senderType === 'basic'
-                ? 'sender' as const
-                : 'recipient' as const;
-            const signerAddress = (finalTransaction as any)[signerSide];
-
-            // Don't have to handle contracts as such are disallowed by RequestParser
-            const account = this.findWalletByAddress(signerAddress, false)!;
-            const signer = account.findSignerForAddress(Nimiq.Address.fromUserFriendlyAddress(signerAddress))!;
-
-            keyId = account.keyId;
-            keyPath = signer.path;
-            keyLabel = account.labelForKeyguard;
-
-            if (signerSide === 'recipient') {
-                senderLabel = this.request.senderLabel || 'Staking Contract';
-                recipientLabel = signer.label;
-            } else if (this.request.layout === 'switch-validator' || this.request.layout === 'unstaking') {
-                // For custom multi-tx layouts the labels are rendered on cards (validator and/or
-                // user-account); do not overwrite with the signer's wallet label.
-                senderLabel = this.request.senderLabel;
-                recipientLabel = this.request.recipientLabel;
-            } else {
-                senderLabel = signer.label;
-                recipientLabel = this.request.recipientLabel || 'Staking Contract';
-            }
-
-            // For staking, senderAddress is always from the first transaction
-            senderAddress = this.request.sender instanceof Nimiq.Address
-                ? this.request.sender
-                : (this.request.sender as any).address;
-            senderType = Nimiq.AccountType.Basic; // Will be overridden per transaction
-        } else if (this.request.sender instanceof Nimiq.Address) {
-            // existence checked in RpcApi
-            const senderAccount = this.findWalletByAddress(this.request.sender.toUserFriendlyAddress(), true)!;
-            const senderContract = senderAccount.findContractByAddress(this.request.sender);
-            const signer = senderAccount.findSignerForAddress(this.request.sender)!;
-
-            senderAddress = this.request.sender;
-            senderLabel = (senderContract || signer).label;
-            senderType = senderContract ? senderContract.type : Nimiq.AccountType.Basic;
-            keyId = senderAccount.keyId;
-            keyPath = signer.path;
-            keyLabel = senderAccount.labelForKeyguard;
-        } else {
-            ({
-                address: senderAddress,
-                label: senderLabel,
-                type: senderType,
-                signerKeyId: keyId,
-                signerKeyPath: keyPath,
-                walletLabel: keyLabel,
-            } = this.request.sender);
-        }
-
         let keyguardRequest: KeyguardClient.SignTransactionRequest;
 
-        // Check if this is a multi-transaction request
-        if (this.request.transactions && this.request.transactions.length > 0) {
-            // Multi-transaction format
-            // Transactions can be ParsedTransactionData[] (from TransactionData[])
-            // or PlainTransaction[] (from Uint8Array[])
+        if (!(this.request.sender instanceof Nimiq.Address)) {
+            // The sender object form is only used internally by the Ledger flows, which route to
+            // SignTransactionLedger, see ParsedSignTransactionRequest in RequestTypes.ts.
+            this.$rpc.reject(new Error('Sign transaction requests with a sender object are not handled here'));
+            return;
+        }
+        // The signer is resolved from the request-level sender, which the request parser verified all transactions
+        // against. The sender's label and account type are resolved from the WalletStore, too.
+        const requestSender = this.request.sender;
+        // existence checked in RpcApi
+        const senderAccount = this.findWalletByAddress(requestSender.toUserFriendlyAddress(), true)!;
+        const senderContract = senderAccount.findContractByAddress(requestSender);
+        const signer = senderAccount.findSignerForAddress(requestSender)!;
 
-            // If we have serialized transactions
-            if (this.request.serializedTransactions) {
-                // For staking transactions, re-serialize from PlainTransaction (like SignStaking does)
-                const transactions = this.request.isStakingRequest && this.request.transactions
-                    ? (this.request.transactions as any[]).map((plainTx: any) =>
-                        Nimiq.Transaction.fromPlain(plainTx).serialize())
-                    : this.request.serializedTransactions;
+        const storeSenderLabel = (senderContract || signer).label;
+        const storeSenderType = senderContract ? senderContract.type : Nimiq.AccountType.Basic;
+        const keyId = senderAccount.keyId;
+        const keyPath = signer.path;
+        const keyLabel = senderAccount.labelForKeyguard;
 
-                if (this.request.layout === 'switch-validator') {
-                    keyguardRequest = {
-                        layout: 'switch-validator',
-                        appName: this.request.appName,
+        // The legacy single-transaction request format does not support specifying the senderType, in which case it is
+        // determined from the WalletStore.
+        patchLegacyRequestSenderType(this.request, storeSenderType);
 
-                        keyId,
-                        keyPath,
-                        keyLabel,
+        let common: CommonRequestProperties | CommonStakingRequestProperties = {
+            appName: this.request.appName,
+            keyId,
+            keyPath,
+            keyLabel,
+            transactions: this.request.transactions.map((tx) => tx.serialize()),
+        };
 
-                        senderLabel,
-                        recipientLabel,
-                        stakerLabel: this.request.stakerLabel,
+        if (this.request.layout === SignTransactionRequestLayout.SWITCH_VALIDATOR
+            || this.request.layout === SignTransactionRequestLayout.UNSTAKING) {
+            common = {
+                ...common,
+                senderLabel: this.request.senderLabel, // labels the from-validator, not the user
+                recipientLabel: this.request.recipientLabel,
+                validatorImageUrl: this.request.validatorImageUrl
+                    ? this.request.validatorImageUrl.toString()
+                    : undefined,
+            };
 
-                        transactions,
-
-                        // The validator being switched to is not passed on: the Keyguard reads it
-                        // from the signed update-staker transaction, so that what it displays is
-                        // what gets signed.
-                        validatorImageUrl: this.request.validatorImageUrl,
-                        fromValidatorAddress: this.request.fromValidatorAddress!,
-                        fromValidatorImageUrl: this.request.fromValidatorImageUrl,
-                    };
-                } else if (this.request.layout === 'unstaking') {
-                    keyguardRequest = {
-                        layout: 'unstaking',
-                        appName: this.request.appName,
-
-                        keyId,
-                        keyPath,
-                        keyLabel,
-
-                        senderLabel,
-                        recipientLabel,
-
-                        transactions,
-
-                        validatorAddress: this.request.validatorAddress!,
-                        validatorImageUrl: this.request.validatorImageUrl,
-                    };
-                } else {
-                    keyguardRequest = {
-                        layout: 'standard',
-                        appName: this.request.appName,
-
-                        keyId,
-                        keyPath,
-                        keyLabel,
-
-                        // For staking transactions, don't include sender field (like SignStaking)
-                        // For non-staking, include it
-                        ...(this.request.isStakingRequest ? {} : {
-                            sender: senderAddress.serialize(),
-                        }),
-                        senderLabel,
-                        recipientLabel,
-
-                        // For staking: re-serialized from PlainTransaction
-                        // For non-staking: original serialized bytes
-                        transactions,
-
-                        // Pass through staking-specific fields (like SignStaking does)
-                        ...(this.request.isStakingRequest ? {
-                            validatorAddress: this.request.validatorAddress,
-                            validatorImageUrl: this.request.validatorImageUrl,
-                        } : {}),
-                    };
-                }
-            } else {
-                // Otherwise, convert ParsedTransactionData or PlainTransaction to TransactionData
-                const firstTx = this.request.transactions[0];
-
-                // Check if transactions are PlainTransaction[] (from serialized) or ParsedTransactionData[]
-                const isPlainTransaction = typeof (firstTx as any).recipient === 'string';
-
-                // Cast to any to avoid union type issues with map()
-                const txArray = this.request.transactions as any[];
-
+            if (this.request.layout === SignTransactionRequestLayout.SWITCH_VALIDATOR) {
                 keyguardRequest = {
-                    layout: 'standard',
-                    appName: this.request.appName,
+                    ...common,
+                    layout: 'switch-validator',
 
-                    keyId,
-                    keyPath,
-                    keyLabel,
+                    stakerLabel: this.request.stakerLabel, // labels the user address
 
-                    recipientLabel,
+                    fromValidatorAddress: this.request.fromValidatorAddress!.toUserFriendlyAddress(),
+                    fromValidatorImageUrl: this.request.fromValidatorImageUrl
+                        ? this.request.fromValidatorImageUrl.toString()
+                        : undefined,
+                };
+            } else {
+                keyguardRequest = {
+                    ...common,
+                    layout: 'unstaking',
 
-                    transactions: txArray.map((tx: any) => {
-                        if (isPlainTransaction) {
-                            // PlainTransaction from serialized format
-                            return {
-                                sender: senderAddress.serialize(),
-                                senderType: tx.senderType || senderType || Nimiq.AccountType.Basic,
-                                senderLabel: tx.senderLabel || senderLabel,
-                                recipient: tx.recipient, // Already a string
-                                recipientType: tx.recipientType === 'basic' ? Nimiq.AccountType.Basic
-                                    : tx.recipientType === 'vesting' ? Nimiq.AccountType.Vesting
-                                    : tx.recipientType === 'htlc' ? Nimiq.AccountType.HTLC
-                                    : tx.recipientType === 'staking' ? Nimiq.AccountType.Staking
-                                    : Nimiq.AccountType.Basic,
-                                recipientLabel: tx.recipientLabel,
-                                recipientData: tx.data,
-                                value: tx.value,
-                                fee: tx.fee,
-                                validityStartHeight: tx.validityStartHeight,
-                                flags: tx.flags,
-                            };
-                        } else {
-                            // ParsedTransactionData from TransactionData format
-                            return {
-                                sender: senderAddress.serialize(),
-                                senderType: tx.senderType || senderType || Nimiq.AccountType.Basic,
-                                senderLabel: tx.senderLabel || senderLabel,
-                                recipient: tx.recipient.serialize(), // Nimiq.Address object
-                                recipientType: tx.recipientType,
-                                recipientLabel: tx.recipientLabel,
-                                recipientData: tx.data,
-                                value: tx.value,
-                                fee: tx.fee,
-                                validityStartHeight: tx.validityStartHeight,
-                                flags: tx.flags,
-                            };
-                        }
-                    }),
+                    validatorAddress: this.request.validatorAddress!.toUserFriendlyAddress(),
                 };
             }
-        } else {
-            // Single transaction format (backward compatible)
+        } else if (this.request.transactions.length > 1) {
+            // Standard layout with multiple transactions. Same as in the Keyguard's request format, no labels are
+            // passed on: the Keyguard displays each transaction's own sender and recipient as plain addresses.
             keyguardRequest = {
+                ...common,
                 layout: 'standard',
-                appName: this.request.appName,
+            };
+        } else {
+            // Standard layout with a single transaction. The Keyguard supports the labels only for this case.
+            const [transaction] = common.transactions;
 
-                keyId,
-                keyPath,
-                keyLabel,
+            keyguardRequest = {
+                ...common,
+                layout: 'standard',
 
-                sender: senderAddress.serialize(),
-                senderLabel,
-                senderType: senderType || Nimiq.AccountType.Basic,
-                recipient: this.request.recipient.serialize(),
-                recipientType: this.request.recipientType,
-                recipientLabel,
-                recipientData: this.request.data,
-                value: this.request.value,
-                fee: this.request.fee,
-                validityStartHeight: this.request.validityStartHeight,
-                flags: this.request.flags,
+                // The sender is the user's own account; its label comes from the user's account data and can not be
+                // set in the request, see SignTransactionRequestStandard.
+                senderLabel: storeSenderLabel,
+                recipientLabel: this.request.recipientLabel,
+
+                transactions: [transaction], // the single transaction request type requires a tuple with a single entry
             };
         }
 

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -43,9 +43,9 @@ export default class SignTransaction extends Vue {
             if (signerSide === 'recipient') {
                 senderLabel = this.request.senderLabel || 'Staking Contract';
                 recipientLabel = signer.label;
-            } else if (this.request.layout === 'switch-validator') {
-                // The from/to validator names live in sender/recipientLabel; do not overwrite
-                // them with the signer's wallet label (Keyguard renders these on the cards).
+            } else if (this.request.layout === 'switch-validator' || this.request.layout === 'unstaking') {
+                // For custom multi-tx layouts the labels are rendered on cards (validator and/or
+                // user-account); do not overwrite with the signer's wallet label.
                 senderLabel = this.request.senderLabel;
                 recipientLabel = this.request.recipientLabel;
             } else {
@@ -117,6 +117,23 @@ export default class SignTransaction extends Vue {
                         fromValidatorImageUrl: this.request.fromValidatorImageUrl,
                         amount: this.request.amount!,
                     };
+                } else if (this.request.layout === 'unstaking') {
+                    keyguardRequest = {
+                        layout: 'unstaking',
+                        appName: this.request.appName,
+
+                        keyId,
+                        keyPath,
+                        keyLabel,
+
+                        senderLabel,
+                        recipientLabel,
+
+                        transactions,
+
+                        validatorAddress: this.request.validatorAddress!,
+                        validatorImageUrl: this.request.validatorImageUrl,
+                    } as any; // Published @nimiq/keyguard-client types not yet republished with 'unstaking'.
                 } else {
                     keyguardRequest = {
                         layout: 'standard',

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -61,7 +61,6 @@ export default class SignTransaction extends Vue {
             common = {
                 ...common,
                 senderLabel: this.request.senderLabel, // labels the from-validator, not the user
-                recipientLabel: this.request.recipientLabel,
                 validatorImageUrl: this.request.validatorImageUrl
                     ? this.request.validatorImageUrl.toString()
                     : undefined,
@@ -72,7 +71,8 @@ export default class SignTransaction extends Vue {
                     ...common,
                     layout: 'switch-validator',
 
-                    stakerLabel: this.request.stakerLabel, // labels the user address
+                    recipientLabel: this.request.recipientLabel, // labels the validator being switched to
+                    stakerLabel: storeSenderLabel, // labels the user address
 
                     fromValidatorAddress: this.request.fromValidatorAddress!.toUserFriendlyAddress(),
                     fromValidatorImageUrl: this.request.fromValidatorImageUrl
@@ -83,6 +83,10 @@ export default class SignTransaction extends Vue {
                 keyguardRequest = {
                     ...common,
                     layout: 'unstaking',
+
+                    // The unstaked funds are paid out to the user's own address (bound to the request sender at parse
+                    // time), so its label comes from the user's account data, not from the request.
+                    recipientLabel: storeSenderLabel,
 
                     validatorAddress: this.request.validatorAddress!.toUserFriendlyAddress(),
                 };
@@ -96,18 +100,22 @@ export default class SignTransaction extends Vue {
             };
         } else {
             // Standard layout with a single transaction. The Keyguard supports the labels only for this case.
-            const [transaction] = common.transactions;
+            const [serializedTransaction] = common.transactions;
+            // The user's own account is the transaction's sender, apart from outgoing staking transactions, e.g.
+            // remove-stake or delete-validator, which are sent from the staking contract and pay out to the request
+            // sender, to which the parsing binds them, see parseSignTransactionRequest.
+            const isUserTheRecipient = this.request.transactions[0].recipient.equals(requestSender);
 
             keyguardRequest = {
                 ...common,
                 layout: 'standard',
 
-                // The sender is the user's own account; its label comes from the user's account data and can not be
-                // set in the request, see SignTransactionRequestStandard.
-                senderLabel: storeSenderLabel,
-                recipientLabel: this.request.recipientLabel,
+                // The user's own account is labeled from the user's account data; a label for it can not be set in
+                // the request, see SignTransactionRequestStandard and parseSignTransactionRequest.
+                senderLabel: isUserTheRecipient ? undefined : storeSenderLabel,
+                recipientLabel: isUserTheRecipient ? storeSenderLabel : this.request.recipientLabel,
 
-                transactions: [transaction], // the single transaction request type requires a tuple with a single entry
+                transactions: [serializedTransaction], // single transaction request type needs tuple with single entry
             };
         }
 

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -111,7 +111,9 @@ export default class SignTransaction extends Vue {
 
                         transactions,
 
-                        validatorAddress: this.request.validatorAddress!,
+                        // The validator being switched to is not passed on: the Keyguard reads it
+                        // from the signed update-staker transaction, so that what it displays is
+                        // what gets signed.
                         validatorImageUrl: this.request.validatorImageUrl,
                         fromValidatorAddress: this.request.fromValidatorAddress!,
                         fromValidatorImageUrl: this.request.fromValidatorImageUrl,
@@ -132,7 +134,7 @@ export default class SignTransaction extends Vue {
 
                         validatorAddress: this.request.validatorAddress!,
                         validatorImageUrl: this.request.validatorImageUrl,
-                    } as any; // Published @nimiq/keyguard-client types not yet republished with 'unstaking'.
+                    };
                 } else {
                     keyguardRequest = {
                         layout: 'standard',

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -108,6 +108,7 @@ export default class SignTransaction extends Vue {
 
                         senderLabel,
                         recipientLabel,
+                        stakerLabel: this.request.stakerLabel,
 
                         transactions,
 

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -43,6 +43,11 @@ export default class SignTransaction extends Vue {
             if (signerSide === 'recipient') {
                 senderLabel = this.request.senderLabel || 'Staking Contract';
                 recipientLabel = signer.label;
+            } else if (this.request.layout === 'switch-validator') {
+                // The from/to validator names live in sender/recipientLabel; do not overwrite
+                // them with the signer's wallet label (Keyguard renders these on the cards).
+                senderLabel = this.request.senderLabel;
+                recipientLabel = this.request.recipientLabel;
             } else {
                 senderLabel = signer.label;
                 recipientLabel = this.request.recipientLabel || 'Staking Contract';
@@ -92,33 +97,55 @@ export default class SignTransaction extends Vue {
                         Nimiq.Transaction.fromPlain(plainTx).serialize())
                     : this.request.serializedTransactions;
 
-                keyguardRequest = {
-                    layout: 'standard',
-                    appName: this.request.appName,
+                if (this.request.layout === 'switch-validator') {
+                    keyguardRequest = {
+                        layout: 'switch-validator',
+                        appName: this.request.appName,
 
-                    keyId,
-                    keyPath,
-                    keyLabel,
+                        keyId,
+                        keyPath,
+                        keyLabel,
 
-                    // For staking transactions, don't include sender field (like SignStaking)
-                    // For non-staking, include it
-                    ...(this.request.isStakingRequest ? {} : {
-                        sender: senderAddress.serialize(),
-                    }),
-                    senderLabel,
-                    recipientLabel,
+                        senderLabel,
+                        recipientLabel,
 
-                    // For staking: re-serialized from PlainTransaction
-                    // For non-staking: original serialized bytes
-                    transactions,
+                        transactions,
 
-                    // Pass through staking-specific fields (like SignStaking does)
-                    ...(this.request.isStakingRequest ? {
-                        validatorAddress: this.request.validatorAddress,
+                        validatorAddress: this.request.validatorAddress!,
                         validatorImageUrl: this.request.validatorImageUrl,
-                        amount: this.request.amount,
-                    } : {}),
-                };
+                        fromValidatorAddress: this.request.fromValidatorAddress!,
+                        fromValidatorImageUrl: this.request.fromValidatorImageUrl,
+                        amount: this.request.amount!,
+                    };
+                } else {
+                    keyguardRequest = {
+                        layout: 'standard',
+                        appName: this.request.appName,
+
+                        keyId,
+                        keyPath,
+                        keyLabel,
+
+                        // For staking transactions, don't include sender field (like SignStaking)
+                        // For non-staking, include it
+                        ...(this.request.isStakingRequest ? {} : {
+                            sender: senderAddress.serialize(),
+                        }),
+                        senderLabel,
+                        recipientLabel,
+
+                        // For staking: re-serialized from PlainTransaction
+                        // For non-staking: original serialized bytes
+                        transactions,
+
+                        // Pass through staking-specific fields (like SignStaking does)
+                        ...(this.request.isStakingRequest ? {
+                            validatorAddress: this.request.validatorAddress,
+                            validatorImageUrl: this.request.validatorImageUrl,
+                            amount: this.request.amount,
+                        } : {}),
+                    };
+                }
             } else {
                 // Otherwise, convert ParsedTransactionData or PlainTransaction to TransactionData
                 const firstTx = this.request.transactions[0];

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -22,8 +22,38 @@ export default class SignTransaction extends Vue {
         let keyId: string;
         let keyPath: string;
         let keyLabel: string | undefined;
+        let recipientLabel: string | undefined = this.request.recipientLabel;
 
-        if (this.request.sender instanceof Nimiq.Address) {
+        // For staking transactions, determine signer by last transaction (like SignStaking does)
+        if (this.request.isStakingRequest && this.request.transactions && this.request.transactions.length > 0) {
+            const finalTransaction = this.request.transactions[this.request.transactions.length - 1];
+            const signerSide = (finalTransaction as any).senderType === 'basic'
+                ? 'sender' as const
+                : 'recipient' as const;
+            const signerAddress = (finalTransaction as any)[signerSide];
+
+            // Don't have to handle contracts as such are disallowed by RequestParser
+            const account = this.findWalletByAddress(signerAddress, false)!;
+            const signer = account.findSignerForAddress(Nimiq.Address.fromUserFriendlyAddress(signerAddress))!;
+
+            keyId = account.keyId;
+            keyPath = signer.path;
+            keyLabel = account.labelForKeyguard;
+
+            if (signerSide === 'recipient') {
+                senderLabel = this.request.senderLabel || 'Staking Contract';
+                recipientLabel = signer.label;
+            } else {
+                senderLabel = signer.label;
+                recipientLabel = this.request.recipientLabel || 'Staking Contract';
+            }
+
+            // For staking, senderAddress is always from the first transaction
+            senderAddress = this.request.sender instanceof Nimiq.Address
+                ? this.request.sender
+                : (this.request.sender as any).address;
+            senderType = Nimiq.AccountType.Basic; // Will be overridden per transaction
+        } else if (this.request.sender instanceof Nimiq.Address) {
             // existence checked in RpcApi
             const senderAccount = this.findWalletByAddress(this.request.sender.toUserFriendlyAddress(), true)!;
             const senderContract = senderAccount.findContractByAddress(this.request.sender);
@@ -46,31 +76,135 @@ export default class SignTransaction extends Vue {
             } = this.request.sender);
         }
 
-        const request: KeyguardClient.SignTransactionRequest = {
-            layout: 'standard',
-            appName: this.request.appName,
+        let keyguardRequest: KeyguardClient.SignTransactionRequest;
 
-            keyId,
-            keyPath,
-            keyLabel,
+        // Check if this is a multi-transaction request
+        if (this.request.transactions && this.request.transactions.length > 0) {
+            // Multi-transaction format
+            // Transactions can be ParsedTransactionData[] (from TransactionData[])
+            // or PlainTransaction[] (from Uint8Array[])
 
-            sender: senderAddress.serialize(),
-            senderLabel,
-            senderType: senderType || Nimiq.AccountType.Basic,
-            recipient: this.request.recipient.serialize(),
-            recipientType: this.request.recipientType,
-            recipientLabel: this.request.recipientLabel,
-            recipientData: this.request.data,
-            value: this.request.value,
-            fee: this.request.fee,
-            validityStartHeight: this.request.validityStartHeight,
-            flags: this.request.flags,
-        };
+            // If we have serialized transactions
+            if (this.request.serializedTransactions) {
+                // For staking transactions, re-serialize from PlainTransaction (like SignStaking does)
+                const transactions = this.request.isStakingRequest && this.request.transactions
+                    ? (this.request.transactions as any[]).map((plainTx: any) =>
+                        Nimiq.Transaction.fromPlain(plainTx).serialize())
+                    : this.request.serializedTransactions;
 
-        staticStore.keyguardRequest = request;
+                keyguardRequest = {
+                    layout: 'standard',
+                    appName: this.request.appName,
 
-        const client = this.$rpc.createKeyguardClient(true);
-        client.signTransaction(request);
+                    keyId,
+                    keyPath,
+                    keyLabel,
+
+                    // For staking transactions, don't include sender field (like SignStaking)
+                    // For non-staking, include it
+                    ...(this.request.isStakingRequest ? {} : {
+                        sender: senderAddress.serialize(),
+                    }),
+                    senderLabel,
+                    recipientLabel,
+
+                    // For staking: re-serialized from PlainTransaction
+                    // For non-staking: original serialized bytes
+                    transactions,
+
+                    // Pass through staking-specific fields (like SignStaking does)
+                    ...(this.request.isStakingRequest ? {
+                        validatorAddress: this.request.validatorAddress,
+                        validatorImageUrl: this.request.validatorImageUrl,
+                        amount: this.request.amount,
+                    } : {}),
+                };
+            } else {
+                // Otherwise, convert ParsedTransactionData or PlainTransaction to TransactionData
+                const firstTx = this.request.transactions[0];
+
+                // Check if transactions are PlainTransaction[] (from serialized) or ParsedTransactionData[]
+                const isPlainTransaction = typeof (firstTx as any).recipient === 'string';
+
+                // Cast to any to avoid union type issues with map()
+                const txArray = this.request.transactions as any[];
+
+                keyguardRequest = {
+                    layout: 'standard',
+                    appName: this.request.appName,
+
+                    keyId,
+                    keyPath,
+                    keyLabel,
+
+                    recipientLabel,
+
+                    transactions: txArray.map((tx: any) => {
+                        if (isPlainTransaction) {
+                            // PlainTransaction from serialized format
+                            return {
+                                sender: senderAddress.serialize(),
+                                senderType: tx.senderType || senderType || Nimiq.AccountType.Basic,
+                                senderLabel: tx.senderLabel || senderLabel,
+                                recipient: tx.recipient, // Already a string
+                                recipientType: tx.recipientType === 'basic' ? Nimiq.AccountType.Basic
+                                    : tx.recipientType === 'vesting' ? Nimiq.AccountType.Vesting
+                                    : tx.recipientType === 'htlc' ? Nimiq.AccountType.HTLC
+                                    : tx.recipientType === 'staking' ? Nimiq.AccountType.Staking
+                                    : Nimiq.AccountType.Basic,
+                                recipientLabel: tx.recipientLabel,
+                                recipientData: tx.data,
+                                value: tx.value,
+                                fee: tx.fee,
+                                validityStartHeight: tx.validityStartHeight,
+                                flags: tx.flags,
+                            };
+                        } else {
+                            // ParsedTransactionData from TransactionData format
+                            return {
+                                sender: senderAddress.serialize(),
+                                senderType: tx.senderType || senderType || Nimiq.AccountType.Basic,
+                                senderLabel: tx.senderLabel || senderLabel,
+                                recipient: tx.recipient.serialize(), // Nimiq.Address object
+                                recipientType: tx.recipientType,
+                                recipientLabel: tx.recipientLabel,
+                                recipientData: tx.data,
+                                value: tx.value,
+                                fee: tx.fee,
+                                validityStartHeight: tx.validityStartHeight,
+                                flags: tx.flags,
+                            };
+                        }
+                    }),
+                };
+            }
+        } else {
+            // Single transaction format (backward compatible)
+            keyguardRequest = {
+                layout: 'standard',
+                appName: this.request.appName,
+
+                keyId,
+                keyPath,
+                keyLabel,
+
+                sender: senderAddress.serialize(),
+                senderLabel,
+                senderType: senderType || Nimiq.AccountType.Basic,
+                recipient: this.request.recipient.serialize(),
+                recipientType: this.request.recipientType,
+                recipientLabel,
+                recipientData: this.request.data,
+                value: this.request.value,
+                fee: this.request.fee,
+                validityStartHeight: this.request.validityStartHeight,
+                flags: this.request.flags,
+            };
+        }
+
+        staticStore.keyguardRequest = keyguardRequest;
+        const keyguardClient = this.$rpc.createKeyguardClient(true);
+        keyguardClient.signTransaction(keyguardRequest);
     }
 }
 </script>

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -115,7 +115,6 @@ export default class SignTransaction extends Vue {
                         validatorImageUrl: this.request.validatorImageUrl,
                         fromValidatorAddress: this.request.fromValidatorAddress!,
                         fromValidatorImageUrl: this.request.fromValidatorImageUrl,
-                        amount: this.request.amount!,
                     };
                 } else if (this.request.layout === 'unstaking') {
                     keyguardRequest = {
@@ -159,7 +158,6 @@ export default class SignTransaction extends Vue {
                         ...(this.request.isStakingRequest ? {
                             validatorAddress: this.request.validatorAddress,
                             validatorImageUrl: this.request.validatorImageUrl,
-                            amount: this.request.amount,
                         } : {}),
                     };
                 }

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -40,6 +40,7 @@
                 <Account layout="column"
                     :address="senderDetails.address"
                     :label="senderDetails.label || senderDetails.address"
+                    :image="senderDetails.image"
                     @click.native="shownAccountDetails = senderDetails"
                     class="blur-target">
                 </Account>
@@ -217,6 +218,11 @@ export default class SignTransactionLedger extends Vue {
         // If user left this view in the meantime, don't continue
         if (this.isDestroyed) return;
 
+        this.senderDetails = {
+            address: '',
+            label: 'senderLabel' in this.request ? this.request.senderLabel : undefined,
+        };
+
         // Collect payment information
         let sender: Nimiq.Address;
         let recipient: Nimiq.Address;
@@ -256,6 +262,13 @@ export default class SignTransactionLedger extends Vue {
                 address: finalTransaction.recipient,
                 label: signStakingRequest.recipientLabel,
             };
+
+            // Render the staking contract as the validator that is being staked with.
+            const stakingContractDetails = finalTransaction.senderType === 'staking'
+                ? this.senderDetails
+                : this.recipientDetails;
+            stakingContractDetails.address = signStakingRequest.validatorAddress || stakingContractDetails.address;
+            stakingContractDetails.image = signStakingRequest.validatorImageUrl;
         } else if (this.request.kind === RequestType.CHECKOUT) {
             // Coming from checkout
             const checkoutRequest = this.request as ParsedCheckoutRequest;
@@ -341,18 +354,15 @@ export default class SignTransactionLedger extends Vue {
             return;
         }
 
-        this.senderDetails = {
-            address: sender.toUserFriendlyAddress(),
-            label: 'senderLabel' in this.request ? this.request.senderLabel : undefined,
-        };
+        this.senderDetails.address = this.senderDetails.address || sender.toUserFriendlyAddress();
 
+        // Find signer key and refine labels based on signer info.
         let signerKeyId: string;
         let signerKeyPath: string;
         let senderType: Nimiq.AccountType | undefined;
-
-        // Find signer key and refine labels based on signer info.
         if ('sender' in this.request && !(this.request.sender instanceof Nimiq.Address)) {
             // It's a sign transaction request with sender info object.
+            // Note that the sender object is currently only for internal use in RefundSwapLedger.
             ({
                 type: senderType,
                 signerKeyId,

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -1,82 +1,79 @@
 <template>
     <div v-if="transactions.length" class="container">
         <SmallPage :class="{ 'account-details-shown': !!shownAccountDetails }">
-            <PaymentInfoLine
-                v-if="request.kind === 'checkout'"
-                ref="info"
-                class="blur-target"
-                :cryptoAmount="{
-                    amount: checkoutPaymentOptions.amount,
-                    currency: checkoutPaymentOptions.currency,
-                    decimals: checkoutPaymentOptions.decimals,
-                }"
-                :fiatAmount="request.fiatAmount && request.fiatCurrency ? {
-                    amount: request.fiatAmount,
-                    currency: request.fiatCurrency,
-                } : null"
-                :fiatApiProvider="constructor.FIAT_API_PROVIDER"
-                :vendorMarkup="checkoutPaymentOptions.vendorMarkup"
-                :networkFee="checkoutPaymentOptions.fee"
-                :address="checkoutPaymentOptions.protocolSpecific.recipient
-                    ? checkoutPaymentOptions.protocolSpecific.recipient.toUserFriendlyAddress()
-                    : null"
-                :origin="rpcState.origin"
-                :shopLogoUrl="request.shopLogoUrl"
-                :startTime="request.time"
-                :endTime="checkoutPaymentOptions.expires"
-            />
-            <PageHeader :back-arrow="request.kind === 'checkout' || request.kind === 'create-cashlink'"
-                @back="_back" class="blur-target">
-                {{
-                    request.kind === 'checkout'
-                        ? $t('Verify Payment')
-                        : request.kind === 'create-cashlink'
-                            ? $t('Confirm Cashlink')
-                            : $t('Confirm Transaction')
-                }}
-            </PageHeader>
+            <template v-if="showsTransactionDetails">
+                <PaymentInfoLine
+                    v-if="request.kind === 'checkout'"
+                    ref="info"
+                    class="blur-target"
+                    :cryptoAmount="{
+                        amount: checkoutPaymentOptions.amount,
+                        currency: checkoutPaymentOptions.currency,
+                        decimals: checkoutPaymentOptions.decimals,
+                    }"
+                    :fiatAmount="request.fiatAmount && request.fiatCurrency ? {
+                        amount: request.fiatAmount,
+                        currency: request.fiatCurrency,
+                    } : null"
+                    :fiatApiProvider="constructor.FIAT_API_PROVIDER"
+                    :vendorMarkup="checkoutPaymentOptions.vendorMarkup"
+                    :networkFee="checkoutPaymentOptions.fee"
+                    :address="checkoutPaymentOptions.protocolSpecific.recipient
+                        ? checkoutPaymentOptions.protocolSpecific.recipient.toUserFriendlyAddress()
+                        : null"
+                    :origin="rpcState.origin"
+                    :shopLogoUrl="request.shopLogoUrl"
+                    :startTime="request.time"
+                    :endTime="checkoutPaymentOptions.expires"
+                />
+                <PageHeader :back-arrow="request.kind === 'checkout' || request.kind === 'create-cashlink'"
+                    @back="_back" class="blur-target">
+                    {{ pageHeaderTitle }}
+                </PageHeader>
 
-            <div class="accounts">
-                <Account layout="column"
-                    :address="senderDetails.address"
-                    :label="senderDetails.label || senderDetails.address"
-                    :image="senderDetails.image"
-                    @click.native="shownAccountDetails = senderDetails"
-                    class="blur-target">
-                </Account>
-                <ArrowRightIcon class="arrow-right blur-target"/>
-                <Account layout="column"
-                    :address="recipientDetails.address"
-                    :label="recipientDetails.label || recipientDetails.address"
-                    :image="recipientDetails.image"
-                    :displayAsCashlink="recipientDetails.isCashlink"
-                    @click.native="shownAccountDetails = recipientDetails.isCashlink ? null : recipientDetails"
-                    class="blur-target">
-                </Account>
-            </div>
+                <div class="accounts">
+                    <Account layout="column"
+                        :address="senderDetails.address"
+                        :label="senderDetails.label || senderDetails.address"
+                        :image="senderDetails.image"
+                        @click.native="shownAccountDetails = senderDetails"
+                        class="blur-target">
+                    </Account>
+                    <ArrowRightIcon class="arrow-right blur-target"/>
+                    <Account layout="column"
+                        :address="recipientDetails.address"
+                        :label="recipientDetails.label || recipientDetails.address"
+                        :image="recipientDetails.image"
+                        :displayAsCashlink="recipientDetails.isCashlink"
+                        @click.native="shownAccountDetails = recipientDetails.isCashlink ? null : recipientDetails"
+                        class="blur-target">
+                    </Account>
+                </div>
 
-            <hr class="blur-target">
+                <hr class="blur-target">
 
-            <Amount class="value nq-light-blue blur-target"
-                :amount="amountAndFee.amount"
-                :minDecimals="2"
-                :maxDecimals="5"
-            />
+                <Amount class="value nq-light-blue blur-target"
+                    :amount="amountAndFee.amount"
+                    :minDecimals="2"
+                    :maxDecimals="5"
+                />
 
-            <div v-if="amountAndFee.fee"
-                class="fee nq-text-s blur-target">
-                + <Amount
-                    :amount="amountAndFee.fee"
-                    :minDecimals="2" :maxDecimals="5"
-                /> {{ $t('fee') }}
-            </div>
+                <div v-if="amountAndFee.fee"
+                    class="fee nq-text-s blur-target">
+                    + <Amount
+                        :amount="amountAndFee.fee"
+                        :minDecimals="2" :maxDecimals="5"
+                    /> {{ $t('fee') }}
+                </div>
 
-            <div v-if="transactionData" class="data nq-text blur-target">
-                {{ transactionData }}
-            </div>
+                <div v-if="transactionData" class="data nq-text blur-target">
+                    {{ transactionData }}
+                </div>
+            </template>
 
-            <div class="bottom-container blur-target" :class="{ 'full-height': state !== constructor.State.OVERVIEW }">
-                <LedgerUi ref="ledger-ui" small :signingStep="signingStep"></LedgerUi>
+            <div class="bottom-container blur-target"
+                :class="{ 'full-height': !showsTransactionDetails || state !== constructor.State.OVERVIEW }">
+                <LedgerUi ref="ledger-ui" :small="showsTransactionDetails" :signingStep="signingStep"></LedgerUi>
                 <transition name="transition-fade">
                     <StatusScreen v-if="state !== constructor.State.OVERVIEW"
                         :state="statusScreenState"
@@ -259,9 +256,7 @@ export default class SignTransactionLedger extends Vue {
 
     private async mounted() {
         const requestKind = this.request.kind;
-        // For checkout and cashlink requests, the transactions are created by the Hub itself, instead of being provided
-        // by the caller or request parser, and are also sent to the network by the Hub, instead of being returned.
-        const isSentByHub = requestKind === RequestType.CHECKOUT || requestKind === RequestType.CREATE_CASHLINK;
+        const isSentByHub = this.isSentByHub;
 
         // A checkout's recipient may be omitted from the request and only be provided by the shop's callback, see
         // RequestParser. CheckoutCard fills it into the payment options in place, but it is lost on a reload, on which
@@ -292,19 +287,12 @@ export default class SignTransactionLedger extends Vue {
         }
 
         if (requestKind === RequestType.SIGN_TRANSACTION) {
-            const signTransactionRequest = this.request as ParsedSignTransactionRequest;
-            const { layout } = signTransactionRequest;
+            const { layout } = this.request as ParsedSignTransactionRequest;
             if (layout !== SignTransactionRequestLayout.STANDARD
                 && layout !== SignTransactionRequestLayout.SWITCH_VALIDATOR
                 && layout !== SignTransactionRequestLayout.UNSTAKING) {
                 this.$rpc.reject(new Error(`Sign-transaction requests with the ${layout} layout are not yet supported `
                     + 'for Ledger accounts'));
-                return;
-            }
-            if (layout === SignTransactionRequestLayout.STANDARD
-                && signTransactionRequest.transactions.length > 1) {
-                this.$rpc.reject(new Error('Multi-transaction sign-transaction requests with the standard layout are '
-                    + 'not yet supported for Ledger accounts'));
                 return;
             }
         }
@@ -564,6 +552,14 @@ export default class SignTransactionLedger extends Vue {
         this._cancelLedgerRequest();
     }
 
+    /**
+     * Whether the request's transactions are created by the Hub itself, instead of being provided by the caller or
+     * request parser, and are also sent to the network by the Hub, instead of being returned to the caller.
+     */
+    private get isSentByHub(): boolean {
+        return this.request.kind === RequestType.CHECKOUT || this.request.kind === RequestType.CREATE_CASHLINK;
+    }
+
     private get checkoutPaymentOptions() {
         // tslint:disable-next-line no-unused-expression
         this.requestRevision; // re-evaluate on changes to the request
@@ -648,8 +644,7 @@ export default class SignTransactionLedger extends Vue {
     }
 
     /**
-     * The transaction the request's display is currently based on. Must only be accessed for requests with
-     * transactions, which is the case wherever anything is rendered.
+     * The transaction the transaction details' display is currently based on for showsTransactionDetails.
      */
     private get finalTransaction(): Nimiq.Transaction {
         const transactions = this.transactions;
@@ -775,6 +770,16 @@ export default class SignTransactionLedger extends Vue {
         return validatorInfo;
     }
 
+    /**
+     * Whether the UI is reduced to only the LedgerUi, without any transaction details. This is the case for
+     * sign-transaction requests with multiple transactions on the standard layout, i.e. arbitrary transactions.
+     */
+    private get showsTransactionDetails(): boolean {
+        return this.request.kind !== RequestType.SIGN_TRANSACTION
+            || (this.request as ParsedSignTransactionRequest).layout !== SignTransactionRequestLayout.STANDARD
+            || this.transactions.length === 1;
+    }
+
     private get amountAndFee() {
         // Display the value of the final transaction currently, and the fees of all transactions. For requests with a
         // single transaction, this is that transaction's value and fee.
@@ -794,7 +799,7 @@ export default class SignTransactionLedger extends Vue {
         if (stakingData) return stakingData;
 
         // Non-staking transactions. For SIGN_TRANSACTION requests, this is the single transaction of the standard
-        // layout; multiple transactions are rejected in mounted.
+        // layout.
         const { data, flags } = this.finalTransaction;
 
         if (!data || data.length === 0) {
@@ -937,15 +942,21 @@ export default class SignTransactionLedger extends Vue {
         const index = Math.min(this.currentlySignedTransactionIndex, transactions.length - 1);
         const transaction = transactions[index];
 
-        const { data: recipientData, senderData } = transaction.toPlain();
+        // Note that toPlain can throw for invalid transactions, and that this getter is evaluated during rendering and
+        // must therefore never throw.
         let stakingDataType: string | undefined;
-        if (transaction.recipientType === Nimiq.AccountType.Staking) {
-            stakingDataType = recipientData.type;
-        } else if (transaction.senderType === Nimiq.AccountType.Staking && senderData) {
-            stakingDataType = senderData.type;
+        try {
+            const { data: recipientData, senderData } = transaction.toPlain();
+            if (transaction.recipientType === Nimiq.AccountType.Staking) {
+                stakingDataType = recipientData.type;
+            } else if (transaction.senderType === Nimiq.AccountType.Staking && senderData) {
+                stakingDataType = senderData.type;
+            }
+        } catch (e) {
+            stakingDataType = undefined; // fall back to the generic instructions
         }
 
-        // Provide instructions for the currently supported multi-transaction flows.
+        // Provide instructions for the known multi-transaction flows.
         let instructions: string;
         switch (stakingDataType) {
             case 'set-active-stake':
@@ -971,6 +982,19 @@ export default class SignTransactionLedger extends Vue {
         };
     }
 
+    private get pageHeaderTitle() {
+        switch (this.request.kind) {
+            case RequestType.CHECKOUT:
+                return this.$t('Verify Payment') as string;
+            case RequestType.CREATE_CASHLINK:
+                return this.$t('Confirm Cashlink') as string;
+            default:
+                return this.transactions.length === 1
+                    ? this.$t('Confirm Transaction') as string
+                    : this.$t('Confirm Transactions') as string;
+        }
+    }
+
     private get statusScreenState() {
         switch (this.state) {
             case SignTransactionLedger.State.FINISHED:
@@ -985,13 +1009,15 @@ export default class SignTransactionLedger extends Vue {
     private get statusScreenTitle() {
         switch (this.state) {
             case SignTransactionLedger.State.SENDING_TRANSACTION:
+                // Requests for which the Hub sends the transactions itself always consist of only a single transaction.
                 return this.request.kind === RequestType.CREATE_CASHLINK
                     ? this.$t('Creating your Cashlink') as string
                     : this.$t('Sending Transaction') as string;
             case SignTransactionLedger.State.FINISHED:
-                return this.request.kind === RequestType.SIGN_TRANSACTION
+                if (this.isSentByHub) return this.$t('Transaction Sent') as string; // always only one
+                return this.transactions.length === 1
                     ? this.$t('Transaction Signed') as string
-                    : this.$t('Transaction Sent') as string;
+                    : this.$t('Transactions Signed') as string;
             case SignTransactionLedger.State.EXPIRED:
                 return this.$t('The offer expired.') as string;
             default:

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -52,7 +52,8 @@
 
                 <hr class="blur-target">
 
-                <Amount class="value nq-light-blue blur-target"
+                <Amount v-if="amountAndFee.amount !== null"
+                    class="value nq-light-blue blur-target"
                     :amount="amountAndFee.amount"
                     :minDecimals="2"
                     :maxDecimals="5"
@@ -780,11 +781,14 @@ export default class SignTransactionLedger extends Vue {
             || this.transactions.length === 1;
     }
 
-    private get amountAndFee() {
+    private get amountAndFee(): { amount: number | null, fee: number } {
         // Display the value of the final transaction currently, and the fees of all transactions. For requests with a
-        // single transaction, this is that transaction's value and fee.
+        // single transaction, this is that transaction's value and fee. Omit zero amounts of signaling transactions.
+        const finalTransaction = this.finalTransaction;
+        // tslint:disable-next-line no-bitwise
+        const isSignaling = !!(finalTransaction.flags & Nimiq.TransactionFlag.Signaling);
         return {
-            amount: Number(this.finalTransaction.value),
+            amount: isSignaling ? null : Number(finalTransaction.value),
             fee: this.transactions.reduce((sum, transaction) => sum + Number(transaction.fee), 0),
         };
     }
@@ -1139,7 +1143,7 @@ export default class SignTransactionLedger extends Vue {
     hr {
         width: 100%;
         height: 1px;
-        margin: 0;
+        margin: 0 0 2rem;
         border: none;
         background: #1F2348;
         opacity: .1;
@@ -1147,7 +1151,6 @@ export default class SignTransactionLedger extends Vue {
 
     .value {
         font-size: 5rem;
-        margin-top: 2rem;
     }
 
     .value >>> .nim {

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -269,6 +269,10 @@ export default class SignTransactionLedger extends Vue {
             recipient = sender;
             value = fee = flags = Number.NaN;
 
+            // Render the transaction's sender, which for outgoing staking transactions, e.g. remove-stake, is the
+            // staking contract instead of the user's address, see the sender binding in the request parsing.
+            // This way, the user's account details below get applied to the side the user is actually on.
+            this.senderDetails.address = signTransactionRequest.transactions[0].sender.toUserFriendlyAddress();
             this.recipientDetails = {
                 address: signTransactionRequest.transactions[0].recipient.toUserFriendlyAddress(),
                 label: signTransactionRequest.recipientLabel,
@@ -436,8 +440,9 @@ export default class SignTransactionLedger extends Vue {
             const userAddressDetails = [this.senderDetails, this.recipientDetails]
                 .find(({ address }) => address === userAddress.toUserFriendlyAddress());
             if (userAddressDetails) {
-                userAddressDetails.label = userAddressDetails.label
-                    || (userAccountContract || userAccountSigner).label;
+                // The label of the user's own address always comes from the user's account data, overwriting a
+                // requested label, which a caller must not be able to set for it.
+                userAddressDetails.label = (userAccountContract || userAccountSigner).label;
                 userAddressDetails.walletLabel = userAddressDetails.walletLabel || userAccount.label;
                 userAddressDetails.balance = userAddressDetails.balance
                     || (userAccountContract || userAccountSigner).balance;

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -170,6 +170,15 @@ interface AccountDetailsData {
     isCashlink?: boolean;
 }
 
+interface StakingValidatorInfo {
+    validatorAddress?: string;
+    validatorImageUrl?: string;
+    // Only set for update-staker transactions, for which the sender is rendered as the old validator.
+    fromValidatorAddress?: string;
+    fromValidatorImageUrl?: string;
+    // Labels are provided via senderLabel and/or recipientLabel on the request.
+}
+
 @Component({components: {
     Account,
     PageBody,
@@ -212,12 +221,13 @@ export default class SignTransactionLedger extends Vue {
     private async mounted() {
         if (this.request.kind === RequestType.SIGN_TRANSACTION) {
             const signTransactionRequest = this.request as ParsedSignTransactionRequest;
-            if (signTransactionRequest.layout !== SignTransactionRequestLayout.STANDARD
-                || signTransactionRequest.transactions.length > 1) {
-                // Multi-transaction requests and the staking layouts are not supported for Ledger accounts yet.
-                // Ledger staking flows currently go through SIGN_STAKING requests instead.
-                this.$rpc.reject(new Error(
-                    'Multi-transaction sign-transaction requests are not yet supported for Ledger accounts'));
+            if (signTransactionRequest.layout === SignTransactionRequestLayout.STANDARD
+                && signTransactionRequest.transactions.length > 1) {
+                // Multi-transaction requests with the standard layout are not supported for Ledger accounts yet. The
+                // staking layouts (switch-validator, unstaking), whose transaction counts are fixed by the request
+                // parsing, are supported and rendered like SIGN_STAKING requests, see stakingValidatorInfo.
+                this.$rpc.reject(new Error('Multi-transaction sign-transaction requests with the standard layout are '
+                    + 'not yet supported for Ledger accounts'));
                 return;
             }
         }
@@ -236,6 +246,9 @@ export default class SignTransactionLedger extends Vue {
             address: '',
             label: 'senderLabel' in this.request ? this.request.senderLabel : undefined,
         };
+
+        // The request's transactions to sign and display, for SIGN_TRANSACTION and SIGN_STAKING requests.
+        const transactions = this.transactions;
 
         // Collect payment information
         let sender: Nimiq.Address;
@@ -269,44 +282,28 @@ export default class SignTransactionLedger extends Vue {
             recipient = sender;
             value = fee = flags = Number.NaN;
 
-            // Render the transaction's sender, which for outgoing staking transactions, e.g. remove-stake, is the
-            // staking contract instead of the user's address, see the sender binding in the request parsing.
-            // This way, the user's account details below get applied to the side the user is actually on.
-            this.senderDetails.address = signTransactionRequest.transactions[0].sender.toUserFriendlyAddress();
-            this.recipientDetails = {
-                address: signTransactionRequest.transactions[0].recipient.toUserFriendlyAddress(),
-                label: signTransactionRequest.recipientLabel,
-            };
+            if (signTransactionRequest.layout === SignTransactionRequestLayout.STANDARD) {
+                // Standard layout with a single transaction (multiple transactions are rejected above). The staking
+                // layouts are rendered based on their final transaction in the shared staking flow block below.
+                const [transaction] = signTransactionRequest.transactions;
+                this.senderDetails.address = transaction.sender.toUserFriendlyAddress(); // might be not the user
+                this.recipientDetails = {
+                    address: transaction.recipient.toUserFriendlyAddress(),
+                    label: signTransactionRequest.recipientLabel,
+                };
+            }
         } else if (this.request.kind === RequestType.SIGN_STAKING) {
             // Direct sign staking request invocation
-            const signStakingRequest = this.request as ParsedSignStakingRequest;
-            // Display the transaction info based on the final transaction. Only extract the info to be displayed, not
-            // the other info to create a transaction, as we can create it from the plain transaction infos directly.
-            const finalTransaction = signStakingRequest.transactions[signStakingRequest.transactions.length - 1];
-            sender = Nimiq.Address.fromString(finalTransaction.sender);
+            // Display the transaction info based on the final transaction.
+            const finalTransaction = transactions![transactions!.length - 1];
+            sender = finalTransaction.sender;
 
-            // Set other values only for correct type checking. They won't be used for request type SIGN_STAKING.
+            // Set other values only for correct type checking. They won't be used for request type SIGN_STAKING as the
+            // transactions to sign are built from the request's transactions directly, see transactions.
             recipient = sender;
             value = fee = flags = Number.NaN;
 
-            this.recipientDetails = {
-                address: finalTransaction.recipient,
-                label: signStakingRequest.recipientLabel,
-            };
-
-            // Render the staking contract as the validator that is being staked with.
-            const stakingContractDetails = finalTransaction.senderType === 'staking'
-                ? this.senderDetails
-                : this.recipientDetails;
-            stakingContractDetails.address = signStakingRequest.validatorAddress || stakingContractDetails.address;
-            stakingContractDetails.image = signStakingRequest.validatorImageUrl;
-
-            // For update-staker, render the sender as the old validator instead of as the user's address (the actual
-            // sender).
-            if (finalTransaction.data.type === 'update-staker') {
-                this.senderDetails.address = signStakingRequest.fromValidatorAddress || this.senderDetails.address;
-                this.senderDetails.image = signStakingRequest.fromValidatorImageUrl;
-            }
+            // The account details are rendered in the shared staking flow block below.
         } else if (this.request.kind === RequestType.CHECKOUT) {
             // Coming from checkout
             const checkoutRequest = this.request as ParsedCheckoutRequest;
@@ -392,6 +389,32 @@ export default class SignTransactionLedger extends Vue {
             return;
         }
 
+        // Staking flows (SIGN_STAKING requests, and SIGN_TRANSACTION requests with a staking layout) are displayed
+        // based on their validator info, see stakingValidatorInfo. Only the info to be displayed is extracted here,
+        // not the info to create the transactions, which are built from the requests' transactions directly in the
+        // transactions getter.
+        const stakingValidatorInfo = this.stakingValidatorInfo;
+        if (stakingValidatorInfo) {
+            const finalTransaction = transactions![transactions!.length - 1];
+            this.senderDetails.address = finalTransaction.sender.toUserFriendlyAddress(); // might be not the user
+            this.recipientDetails = {
+                address: finalTransaction.recipient.toUserFriendlyAddress(),
+                label: (this.request as ParsedSignStakingRequest | ParsedSignTransactionRequest).recipientLabel,
+            };
+
+            // Render the staking contract as the validator that is being staked with.
+            const stakingContractDetails = finalTransaction.senderType === Nimiq.AccountType.Staking
+                ? this.senderDetails
+                : this.recipientDetails;
+            stakingContractDetails.address = stakingValidatorInfo.validatorAddress || stakingContractDetails.address;
+            stakingContractDetails.image = stakingValidatorInfo.validatorImageUrl;
+
+            // For update-staker, render the sender as the old validator instead of as the user's address (the actual
+            // sender), see stakingValidatorInfo.
+            this.senderDetails.address = stakingValidatorInfo.fromValidatorAddress || this.senderDetails.address;
+            this.senderDetails.image = stakingValidatorInfo.fromValidatorImageUrl || this.senderDetails.image;
+        }
+
         this.senderDetails.address = this.senderDetails.address || sender.toUserFriendlyAddress();
 
         // Find signer key and refine labels based on signer info.
@@ -412,14 +435,17 @@ export default class SignTransactionLedger extends Vue {
         } else {
             let userAddress: Nimiq.Address; // might be a regular address or a contract address
             if (this.request.kind === RequestType.SIGN_STAKING) {
-                // For staking, the sender or recipient address might be the user's address.
-                const { transactions } = this.request as ParsedSignStakingRequest;
-                const finalTransaction = transactions[transactions.length - 1];
-                userAddress = Nimiq.Address.fromString(
-                    finalTransaction.senderType === 'basic' ? finalTransaction.sender : finalTransaction.recipient,
-                );
+                // For staking, the sender or recipient address might be the user's address, and there is no request-
+                // level sender that the parser already parses this information to.
+                const finalTransaction = transactions![transactions!.length - 1];
+                userAddress = finalTransaction.senderType === Nimiq.AccountType.Basic
+                    ? finalTransaction.sender
+                    : finalTransaction.recipient;
                 // No need to set senderType, as we're not using it for SIGN_STAKING requests.
             } else {
+                // For SIGN_TRANSACTION the request-level sender is the user's address for all layouts, as the request
+                // parsing binds basic and contract senders to it, and outgoing staking transactions, e.g. remove-stake
+                // of the multi-tx unstaking layout, to pay out to it, see parseSignTransactionRequest.
                 userAddress = sender;
             }
 
@@ -458,11 +484,7 @@ export default class SignTransactionLedger extends Vue {
             recipientType?: Nimiq.AccountType,
             validityStartHeight?: number,
         }> = [];
-        if (this.request.kind === RequestType.SIGN_TRANSACTION || this.request.kind === RequestType.SIGN_STAKING) {
-            const transactions = this.request.kind === RequestType.SIGN_TRANSACTION
-                ? (this.request as ParsedSignTransactionRequest).transactions
-                : (this.request as ParsedSignStakingRequest).transactions
-                    .map((plainTransaction) => Nimiq.Transaction.fromPlain(plainTransaction));
+        if (transactions) { // SIGN_TRANSACTION or SIGN_STAKING request
             const propertiesToCopy = [
                 'sender',
                 'senderType',
@@ -604,6 +626,71 @@ export default class SignTransactionLedger extends Vue {
         ) as ParsedNimiqDirectPaymentOptions;
     }
 
+    /**
+     * The request's transactions to sign and display, for SIGN_TRANSACTION and SIGN_STAKING requests. Null for other
+     * request types.
+     */
+    private get transactions(): Nimiq.Transaction[] | null {
+        switch (this.request.kind) {
+            case RequestType.SIGN_TRANSACTION:
+                return (this.request as ParsedSignTransactionRequest).transactions;
+            case RequestType.SIGN_STAKING:
+                return (this.request as ParsedSignStakingRequest).transactions
+                    .map((plainTransaction) => Nimiq.Transaction.fromPlain(plainTransaction));
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Validator info of staking flows, which are displayed based on their final transaction and this info: SIGN_STAKING
+     * requests, and SIGN_TRANSACTION requests with a staking layout (switch-validator, unstaking). Null for other
+     * requests. The from-validator info is only included for update-staker transactions, see StakingValidatorInfo.
+     */
+    private get stakingValidatorInfo(): StakingValidatorInfo | null {
+        let validatorInfo: StakingValidatorInfo | null = null;
+        if (this.request.kind === RequestType.SIGN_STAKING) {
+            const {
+                validatorAddress,
+                validatorImageUrl,
+                fromValidatorAddress,
+                fromValidatorImageUrl,
+            } = this.request as ParsedSignStakingRequest;
+            validatorInfo = { validatorAddress, validatorImageUrl, fromValidatorAddress, fromValidatorImageUrl };
+        } else if (this.request.kind === RequestType.SIGN_TRANSACTION) {
+            const signTransactionRequest = this.request as ParsedSignTransactionRequest;
+            if (signTransactionRequest.layout === SignTransactionRequestLayout.SWITCH_VALIDATOR
+                || signTransactionRequest.layout === SignTransactionRequestLayout.UNSTAKING) {
+                const {
+                    validatorAddress,
+                    validatorImageUrl,
+                    fromValidatorAddress,
+                    fromValidatorImageUrl,
+                } = signTransactionRequest;
+                validatorInfo = {
+                    validatorAddress: validatorAddress ? validatorAddress.toUserFriendlyAddress() : undefined,
+                    validatorImageUrl: validatorImageUrl ? validatorImageUrl.toString() : undefined,
+                    fromValidatorAddress: fromValidatorAddress
+                        ? fromValidatorAddress.toUserFriendlyAddress()
+                        : undefined,
+                    fromValidatorImageUrl: fromValidatorImageUrl ? fromValidatorImageUrl.toString() : undefined,
+                };
+            }
+        }
+        if (!validatorInfo) return null;
+
+        // Only for update-staker, the sender is rendered as the old validator instead of as the user's address (the
+        // actual sender). Don't provide the from-validator info for other transactions, regardless of the request's
+        // info, which is not thoroughly validated against the transactions for SIGN_STAKING requests.
+        const transactions = this.transactions!;
+        const finalTransaction = transactions[transactions.length - 1];
+        if (finalTransaction.toPlain().data.type !== 'update-staker') {
+            validatorInfo.fromValidatorAddress = undefined;
+            validatorInfo.fromValidatorImageUrl = undefined;
+        }
+        return validatorInfo;
+    }
+
     private get amountAndFee() {
         let amount: number;
         let fee: number;
@@ -611,15 +698,13 @@ export default class SignTransactionLedger extends Vue {
             ({ amount, fee } = this.checkoutPaymentOptions);
         } else if (this.cashlink) {
             ({ value: amount, fee } = this.cashlink);
-        } else if (this.request.kind === RequestType.SIGN_TRANSACTION) {
-            const { transactions } = this.request as ParsedSignTransactionRequest;
-            amount = Number(transactions[0].value);
-            fee = Number(transactions[0].fee);
-        } else { // SIGN_STAKING request
-            const { transactions } = this.request as ParsedSignStakingRequest;
+        } else { // SIGN_TRANSACTION or SIGN_STAKING request
+            // Display the value of the final transaction, and the fees of all transactions. For a standard layout
+            // SIGN_TRANSACTION request, this is the single transaction's value and fee.
+            const transactions = this.transactions!;
             const finalTransaction = transactions[transactions.length - 1];
-            amount = finalTransaction.value;
-            fee = transactions.reduce((sum, transaction) => sum + transaction.fee, 0);
+            amount = Number(finalTransaction.value);
+            fee = transactions.reduce((sum, transaction) => sum + Number(transaction.fee), 0);
         }
         return { amount, fee };
     }
@@ -629,18 +714,22 @@ export default class SignTransactionLedger extends Vue {
             return this.cashlink ? this.cashlink.message : null;
         }
 
-        if (this.request.kind === RequestType.SIGN_STAKING) {
-            return this.stakingInfo;
-        }
+        // Staking transactions of SIGN_STAKING requests and SIGN_TRANSACTION requests.
+        const stakingData = this.stakingData;
+        if (stakingData) return stakingData;
 
         let data;
         let flags;
         if (this.request.kind === RequestType.SIGN_TRANSACTION) {
+            // Standard layout with a single, non-staking transaction. Multiple transactions are rejected in mounted(),
+            // and staking transactions, including the staking layouts, are handled via stakingData above.
             const [transaction] = (this.request as ParsedSignTransactionRequest).transactions;
             data = transaction.data;
             flags = transaction.flags;
-        } else { // Checkout
+        } else if (this.request.kind === RequestType.CHECKOUT) {
             ({ extraData: data, flags } = this.checkoutPaymentOptions!.protocolSpecific);
+        } else { // SIGN_STAKING request without staking info; not expected to happen
+            return null;
         }
 
         if (!data || data.length === 0) {
@@ -658,16 +747,21 @@ export default class SignTransactionLedger extends Vue {
             : Nimiq.BufferUtils.toHex(data);
     }
 
-    private get stakingInfo() {
-        if (this.request.kind !== RequestType.SIGN_STAKING) return null;
-
-        const { transactions } = this.request as ParsedSignStakingRequest;
+    private get stakingData() {
+        // Staking data for SIGN_STAKING and SIGN_TRANSACTION requests whose final transaction is a staking transaction,
+        // e.g. of the switch-validator or unstaking layouts, or a single staking transaction on the standard layout.
+        const transactions = this.transactions;
+        if (!transactions) return null;
         // Display data based on final transaction.
         const finalTransaction = transactions[transactions.length - 1];
-        const { sender, senderData, recipientType, data: recipientData } = finalTransaction;
+        const isIncomingStakingTransaction = finalTransaction.recipientType === Nimiq.AccountType.Staking;
+        const isOutgoingStakingTransaction = finalTransaction.senderType === Nimiq.AccountType.Staking;
+        if (!isIncomingStakingTransaction && !isOutgoingStakingTransaction) return null;
+        // Decode the staking data, which is the recipient data for incoming and the sender data for outgoing staking
+        // transactions, into its plain form.
+        const { sender, senderData, data: recipientData } = finalTransaction.toPlain();
 
-        // That either the recipient or the sender is a staking account type is validated in RequestParser
-        if (recipientType === 'staking') {
+        if (isIncomingStakingTransaction) {
             switch (recipientData.type) {
                 case 'create-staker': {
                     let text = 'Start staking';
@@ -751,7 +845,7 @@ export default class SignTransactionLedger extends Vue {
                     return `Unrecognized incoming staking data: ${recipientData.type} - ${recipientData.raw}`;
                 }
             }
-        } else { // recipientType === Nimiq.AccountType.Staking
+        } else { // outgoing staking transaction
             // @ts-ignore Missmatch with Nimiq.PlainTransactionDetails from fastspot-api
             switch (senderData.type) {
                 case 'remove-stake': {

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -269,6 +269,13 @@ export default class SignTransactionLedger extends Vue {
                 : this.recipientDetails;
             stakingContractDetails.address = signStakingRequest.validatorAddress || stakingContractDetails.address;
             stakingContractDetails.image = signStakingRequest.validatorImageUrl;
+
+            // For update-staker, render the sender as the old validator instead of as the user's address (the actual
+            // sender).
+            if (finalTransaction.data.type === 'update-staker') {
+                this.senderDetails.address = signStakingRequest.fromValidatorAddress || this.senderDetails.address;
+                this.senderDetails.image = signStakingRequest.fromValidatorImageUrl;
+            }
         } else if (this.request.kind === RequestType.CHECKOUT) {
             // Coming from checkout
             const checkoutRequest = this.request as ParsedCheckoutRequest;
@@ -386,10 +393,7 @@ export default class SignTransactionLedger extends Vue {
             }
 
             // We know that these exist as their existence was already checked in RpcApi.ts
-            const userAddressDetails = userAddress.toUserFriendlyAddress() === this.senderDetails.address
-                ? this.senderDetails
-                : this.recipientDetails;
-            const userAccount = this.findWalletByAddress(userAddressDetails.address, true)!;
+            const userAccount = this.findWalletByAddress(userAddress.toUserFriendlyAddress(), true)!;
             const userAccountContract = userAccount.findContractByAddress(userAddress);
             const userAccountSigner = userAccount.findSignerForAddress(userAddress)!;
 
@@ -399,10 +403,18 @@ export default class SignTransactionLedger extends Vue {
                 ? userAccountContract.type
                 : Nimiq.AccountType.Basic;
 
-            userAddressDetails.label = userAddressDetails.label || (userAccountContract || userAccountSigner).label;
-            userAddressDetails.walletLabel = userAddressDetails.walletLabel || userAccount.label;
-            userAddressDetails.balance = userAddressDetails.balance
-                || (userAccountContract || userAccountSigner).balance;
+            // In the UI, the user can represent the sender (typical case), recipient (for unstaking) or none of those
+            // (for update-staker / switch-validator). If one of those is rendered as the user details, enrich them with
+            // the wallet label and balance.
+            const userAddressDetails = [this.senderDetails, this.recipientDetails]
+                .find(({ address }) => address === userAddress.toUserFriendlyAddress());
+            if (userAddressDetails) {
+                userAddressDetails.label = userAddressDetails.label
+                    || (userAccountContract || userAccountSigner).label;
+                userAddressDetails.walletLabel = userAddressDetails.walletLabel || userAccount.label;
+                userAddressDetails.balance = userAddressDetails.balance
+                    || (userAccountContract || userAccountSigner).balance;
+            }
         }
 
         // Collect transaction infos to pass to LedgerApi

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="request.kind === 'create-cashlink' ? !!cashlink : true" class="container">
+    <div v-if="transactions.length" class="container">
         <SmallPage :class="{ 'account-details-shown': !!shownAccountDetails }">
             <PaymentInfoLine
                 v-if="request.kind === 'checkout'"
@@ -148,7 +148,6 @@ import { Currency, RequestType, SignedTransaction } from '../../client/PublicReq
 import { patchLegacyRequestSenderType } from '../lib/SignTransactionRequestParsing';
 import { WalletInfo } from '../lib/WalletInfo';
 import {
-    CASHLINK_FUNDING_DATA,
     ERROR_CANCELED,
     ERROR_REQUEST_TIMED_OUT,
     TX_VALIDITY_WINDOW,
@@ -161,6 +160,11 @@ import Cashlink from '../lib/Cashlink';
 import { CashlinkStore } from '../lib/CashlinkStore';
 import CheckoutServerApi from '../lib/CheckoutServerApi';
 
+// Placeholder validity start height for the transactions the Hub creates itself, i.e. for checkout and cashlink
+// requests, the actual height of which is only fetched from the network when the transactions are to be signed, see
+// mounted().
+const PLACEHOLDER_VALIDITY_START_HEIGHT = 0;
+
 interface AccountDetailsData {
     address: string;
     label?: string;
@@ -168,6 +172,18 @@ interface AccountDetailsData {
     walletLabel?: string;
     balance?: number;
     isCashlink?: boolean;
+}
+
+interface UserAccountInfo {
+    // Key to sign the request's transactions with.
+    keyId: string;
+    keyPath: string;
+    // Type of the user's address, i.e. basic, or a contract type for contracts.
+    accountType: Nimiq.AccountType;
+    // Data to display for the user's address, where it is rendered.
+    label?: string;
+    walletLabel?: string;
+    balance?: number;
 }
 
 interface StakingValidatorInfo {
@@ -216,16 +232,76 @@ export default class SignTransactionLedger extends Vue {
     private recipientDetails: AccountDetailsData = { address: '' };
     private shownAccountDetails: AccountDetailsData | null = null;
     private isDestroyed: boolean = false;
+    // Counter to be incremented after in-place changes to the request, which is not reactive itself, to re-evaluate
+    // the getters that are based on it, see transactions getter.
+    private requestRevision: number = 0;
+    // An error that prevented the request from being set up, see created().
+    private _setupError: Error | null = null;
     private _checkoutExpiryTimeout: number = -1;
 
+    private created() {
+        if (this.request.kind !== RequestType.SIGN_TRANSACTION) return;
+        try {
+            // The legacy single-transaction request format does not support specifying the senderType, in which case it
+            // is determined from the WalletStore. As the request's transaction is patched in place, this has to happen
+            // before the transactions getter is evaluated for the first time, which the initial render does.
+            patchLegacyRequestSenderType(
+                this.request as ParsedSignTransactionRequest,
+                this.userAccountInfo.accountType,
+            );
+        } catch (e) {
+            // Vue swallows exceptions thrown in lifecycle hooks, which would leave the senderType unpatched while the
+            // view renders as usual. Fail the request instead, see the transactions getter.
+            this._setupError = e;
+        }
+    }
+
     private async mounted() {
-        if (this.request.kind === RequestType.SIGN_TRANSACTION) {
+        const requestKind = this.request.kind;
+        // For checkout and cashlink requests, the transactions are created by the Hub itself, instead of being provided
+        // by the caller or request parser, and are also sent to the network by the Hub, instead of being returned.
+        const isSentByHub = requestKind === RequestType.CHECKOUT || requestKind === RequestType.CREATE_CASHLINK;
+
+        // A checkout's recipient may be omitted from the request and only be provided by the shop's callback, see
+        // RequestParser. CheckoutCard fills it into the payment options in place, but it is lost on a reload, on which
+        // the request is re-parsed from its original raw form. Defer the check for these requests until after the
+        // payment options have been updated below.
+        const canRecoverCheckoutRecipient = requestKind === RequestType.CHECKOUT
+            && !!(this.request as ParsedCheckoutRequest).callbackUrl
+            && !!(this.request as ParsedCheckoutRequest).csrf;
+
+        const transactionsError = this.transactionsError;
+        if (transactionsError && !canRecoverCheckoutRecipient) {
+            // The request can not be handled. Note that nothing is rendered in this case, see the template's root.
+            const isSupportedRequestKind = requestKind === RequestType.SIGN_TRANSACTION
+                || requestKind === RequestType.SIGN_STAKING
+                || requestKind === RequestType.CHECKOUT
+                || requestKind === RequestType.CREATE_CASHLINK;
+            if (!isSupportedRequestKind && history.length >= 3) {
+                // First history entry is root, the second an original request handler invoking the transaction signing
+                // and the third is this one. If there was an original request handler calling us but the intermediate
+                // transaction signing request was lost on reload and instead the original request recovered from the
+                // RPC state, navigate back to the original request handler.
+                // TODO implementing a proper request call stack instead of the originalRouteName hack would avoid this
+                history.back();
+            } else {
+                this.$rpc.reject(transactionsError);
+            }
+            return;
+        }
+
+        if (requestKind === RequestType.SIGN_TRANSACTION) {
             const signTransactionRequest = this.request as ParsedSignTransactionRequest;
-            if (signTransactionRequest.layout === SignTransactionRequestLayout.STANDARD
+            const { layout } = signTransactionRequest;
+            if (layout !== SignTransactionRequestLayout.STANDARD
+                && layout !== SignTransactionRequestLayout.SWITCH_VALIDATOR
+                && layout !== SignTransactionRequestLayout.UNSTAKING) {
+                this.$rpc.reject(new Error(`Sign-transaction requests with the ${layout} layout are not yet supported `
+                    + 'for Ledger accounts'));
+                return;
+            }
+            if (layout === SignTransactionRequestLayout.STANDARD
                 && signTransactionRequest.transactions.length > 1) {
-                // Multi-transaction requests with the standard layout are not supported for Ledger accounts yet. The
-                // staking layouts (switch-validator, unstaking), whose transaction counts are fixed by the request
-                // parsing, are supported and rendered like SIGN_STAKING requests, see stakingValidatorInfo.
                 this.$rpc.reject(new Error('Multi-transaction sign-transaction requests with the standard layout are '
                     + 'not yet supported for Ledger accounts'));
                 return;
@@ -233,7 +309,7 @@ export default class SignTransactionLedger extends Vue {
         }
 
         const network = this.$refs.network as Network;
-        if (this.request.kind === RequestType.CHECKOUT || this.request.kind === RequestType.CREATE_CASHLINK) {
+        if (isSentByHub) {
             // Pre-connect to network when we know we'll need it. Does not need to be awaited, as the methods on network
             // that actually need to be connected, themselves ensure to be connected.
             network.getNetworkClient().catch(() => {}); // tslint:disable-line no-empty
@@ -242,69 +318,13 @@ export default class SignTransactionLedger extends Vue {
         // If user left this view in the meantime, don't continue
         if (this.isDestroyed) return;
 
-        this.senderDetails = {
-            address: '',
-            label: 'senderLabel' in this.request ? this.request.senderLabel : undefined,
-        };
-
-        // The request's transactions to sign and display, for SIGN_TRANSACTION and SIGN_STAKING requests.
-        const transactions = this.transactions;
-
-        // Collect payment information
-        let sender: Nimiq.Address;
-        let recipient: Nimiq.Address;
-        let value: number;
-        let fee: number;
+        // Collect the request specific display information and side effects, and the validity start height for the
+        // transactions the Hub creates itself. The transactions themselves are built in the transactions getter.
         let validityStartHeightPromise: Promise<number> | undefined;
-        let recipientData: Uint8Array | undefined;
-        let flags: number;
-        if (this.request.kind === RequestType.SIGN_TRANSACTION) {
-            // Direct sign transaction request invocation
-            const signTransactionRequest = this.request as ParsedSignTransactionRequest;
-            sender = signTransactionRequest.sender instanceof Nimiq.Address
-                ? signTransactionRequest.sender
-                : signTransactionRequest.sender.address;
-
-            // The legacy single-transaction request format does not support specifying the senderType, in which case
-            // it is determined from the WalletStore.
-            let storeSenderType = Nimiq.AccountType.Basic;
-            if (!(signTransactionRequest.sender instanceof Nimiq.Address)) {
-                storeSenderType = signTransactionRequest.sender.type || Nimiq.AccountType.Basic;
-            } else {
-                // existence checked in RpcApi
-                const senderContract = this.findWalletByAddress(sender.toUserFriendlyAddress(), true)!
-                    .findContractByAddress(sender);
-                if (senderContract) storeSenderType = senderContract.type;
-            }
-            patchLegacyRequestSenderType(signTransactionRequest, storeSenderType);
-
-            // Set other values only for correct type checking. They won't be used for request type SIGN_TRANSACTION.
-            recipient = sender;
-            value = fee = flags = Number.NaN;
-
-            if (signTransactionRequest.layout === SignTransactionRequestLayout.STANDARD) {
-                // Standard layout with a single transaction (multiple transactions are rejected above). The staking
-                // layouts are rendered based on their final transaction in the shared staking flow block below.
-                const [transaction] = signTransactionRequest.transactions;
-                this.senderDetails.address = transaction.sender.toUserFriendlyAddress(); // might be not the user
-                this.recipientDetails = {
-                    address: transaction.recipient.toUserFriendlyAddress(),
-                    label: signTransactionRequest.recipientLabel,
-                };
-            }
-        } else if (this.request.kind === RequestType.SIGN_STAKING) {
-            // Direct sign staking request invocation
-            // Display the transaction info based on the final transaction.
-            const finalTransaction = transactions![transactions!.length - 1];
-            sender = finalTransaction.sender;
-
-            // Set other values only for correct type checking. They won't be used for request type SIGN_STAKING as the
-            // transactions to sign are built from the request's transactions directly, see transactions.
-            recipient = sender;
-            value = fee = flags = Number.NaN;
-
-            // The account details are rendered in the shared staking flow block below.
-        } else if (this.request.kind === RequestType.CHECKOUT) {
+        let recipientLabel = 'recipientLabel' in this.request ? this.request.recipientLabel : undefined;
+        let recipientImage: string | undefined;
+        let isRecipientCashlink = false;
+        if (requestKind === RequestType.CHECKOUT) {
             // Coming from checkout
             const checkoutRequest = this.request as ParsedCheckoutRequest;
             const $subtitle = document.querySelector('.logo .logo-subtitle')!;
@@ -326,25 +346,22 @@ export default class SignTransactionLedger extends Vue {
                         checkoutRequest.csrf,
                     );
                     checkoutPaymentOptions.update(fetchedPaymentOptions);
+                    // The payment options were updated in place and are not reactive themselves, therefore trigger a
+                    // re-evaluation of the getters based on them, especially of the transaction to sign and display.
+                    this.requestRevision++;
                 } catch (e) {
                     this.$rpc.reject(e);
                     return;
                 }
             }
-            if (!checkoutPaymentOptions.protocolSpecific.recipient) {
-                this.$rpc.reject(new Error('Failed to fetch checkout recipient.'));
+            const transactionsErrorForNewRequestRevision = this.transactionsError;
+            if (transactionsErrorForNewRequestRevision) {
+                this.$rpc.reject(transactionsErrorForNewRequestRevision);
                 return;
             }
 
-            sender = Nimiq.Address.fromString(this.$store.state.activeUserFriendlyAddress);
-            ({ amount: value, fee } = checkoutPaymentOptions);
-            ({ recipient, flags, extraData: recipientData } = checkoutPaymentOptions.protocolSpecific);
-
-            this.recipientDetails = {
-                address: recipient.toUserFriendlyAddress(),
-                label: this.rpcState.origin.split('://')[1],
-                image: checkoutRequest.shopLogoUrl,
-            };
+            recipientLabel = this.rpcState.origin.split('://')[1];
+            recipientImage = checkoutRequest.shopLogoUrl;
 
             // Usually instant as synced in checkout. Only on reload we have to resync.
             validityStartHeightPromise = network.getBlockchainHeight().then((blockchainHeight) =>
@@ -357,37 +374,32 @@ export default class SignTransactionLedger extends Vue {
             if (checkoutPaymentOptions.expires) {
                 this._initializeCheckoutExpiryTimer().catch((e) => this.$rpc.reject(e));
             }
-        } else if (this.request.kind === RequestType.CREATE_CASHLINK) {
+        } else if (requestKind === RequestType.CREATE_CASHLINK) {
             // Coming from cashlink create
-            if (!this.cashlink) {
-                this.$rpc.reject( new Error('Ledger Cashlink Signing expects the Cashlink to sign to be in the '
-                    + 'static store.'));
-                return;
-            }
-            sender = Nimiq.Address.fromString(this.$store.state.activeUserFriendlyAddress);
-            ({ recipient, value, fee } = this.cashlink!.getFundingDetails());
+            recipientLabel = this.$t('New Cashlink') as string;
+            isRecipientCashlink = true;
             validityStartHeightPromise = network.getBlockchainHeight().then((blockchainHeight) => blockchainHeight + 1);
-            recipientData = CASHLINK_FUNDING_DATA;
-            flags = Nimiq.TransactionFlag.None;
-
-            this.recipientDetails = {
-                address: this.cashlink.address.toUserFriendlyAddress(),
-                label: this.$t('New Cashlink') as string,
-                isCashlink: true,
-            };
-        } else if (history.length >= 3) {
-            // First history entry is root, the second an original request handler invoking the transaction signing
-            // and the third is this one. If there was an original request handler calling us but the intermediate
-            // transaction signing request was lost on reload and instead the original request recovered from the
-            // RPC state, navigate back to the original request handler.
-            // TODO implementing a proper request call stack instead of the originalRouteName hack would avoid this
-            history.back();
-            return;
-        } else {
-            this.$rpc.reject(new Error('Legder Transaction Signing must be invoked via sign-transaction, sign-staking,'
-                + 'checkout or cashlink requests.'));
-            return;
         }
+
+        // Display the transaction info based on the final transaction, for all request types. Note that all optional
+        // properties are initialized, also those that are only assigned below, to make them reactive.
+        const transactions = this.transactions; // from here on the transactions should not change anymore
+        const finalTransaction = this.finalTransaction;
+        this.senderDetails = {
+            address: finalTransaction.sender.toUserFriendlyAddress(), // might be not the user
+            label: 'senderLabel' in this.request ? this.request.senderLabel : undefined,
+            image: undefined,
+            walletLabel: undefined,
+            balance: undefined,
+        };
+        this.recipientDetails = {
+            address: finalTransaction.recipient.toUserFriendlyAddress(), // might be the user
+            label: recipientLabel,
+            image: recipientImage,
+            walletLabel: undefined,
+            balance: undefined,
+            isCashlink: isRecipientCashlink,
+        };
 
         // Staking flows (SIGN_STAKING requests, and SIGN_TRANSACTION requests with a staking layout) are displayed
         // based on their validator info, see stakingValidatorInfo. Only the info to be displayed is extracted here,
@@ -395,144 +407,62 @@ export default class SignTransactionLedger extends Vue {
         // transactions getter.
         const stakingValidatorInfo = this.stakingValidatorInfo;
         if (stakingValidatorInfo) {
-            const finalTransaction = transactions![transactions!.length - 1];
-            this.senderDetails.address = finalTransaction.sender.toUserFriendlyAddress(); // might be not the user
-            this.recipientDetails = {
-                address: finalTransaction.recipient.toUserFriendlyAddress(),
-                label: (this.request as ParsedSignStakingRequest | ParsedSignTransactionRequest).recipientLabel,
-            };
-
             // Render the staking contract as the validator that is being staked with.
             const stakingContractDetails = finalTransaction.senderType === Nimiq.AccountType.Staking
                 ? this.senderDetails
                 : this.recipientDetails;
-            stakingContractDetails.address = stakingValidatorInfo.validatorAddress || stakingContractDetails.address;
-            stakingContractDetails.image = stakingValidatorInfo.validatorImageUrl;
+            // Only ever show a validator's image on a card that actually renders that validator's address.
+            if (stakingValidatorInfo.validatorAddress) {
+                stakingContractDetails.address = stakingValidatorInfo.validatorAddress;
+                stakingContractDetails.image = stakingValidatorInfo.validatorImageUrl;
+            }
 
             // For update-staker, render the sender as the old validator instead of as the user's address (the actual
             // sender), see stakingValidatorInfo.
-            this.senderDetails.address = stakingValidatorInfo.fromValidatorAddress || this.senderDetails.address;
-            this.senderDetails.image = stakingValidatorInfo.fromValidatorImageUrl || this.senderDetails.image;
-        }
-
-        this.senderDetails.address = this.senderDetails.address || sender.toUserFriendlyAddress();
-
-        // Find signer key and refine labels based on signer info.
-        let signerKeyId: string;
-        let signerKeyPath: string;
-        let senderType: Nimiq.AccountType | undefined;
-        if ('sender' in this.request && !(this.request.sender instanceof Nimiq.Address)) {
-            // It's a sign transaction request with sender info object.
-            // Note that the sender object is currently only for internal use in RefundSwapLedger.
-            ({
-                type: senderType,
-                signerKeyId,
-                signerKeyPath,
-            } = this.request.sender);
-
-            this.senderDetails.label = this.senderDetails.label || this.request.sender.label;
-            this.senderDetails.walletLabel = this.senderDetails.walletLabel || this.request.sender.walletLabel;
-        } else {
-            let userAddress: Nimiq.Address; // might be a regular address or a contract address
-            if (this.request.kind === RequestType.SIGN_STAKING) {
-                // For staking, the sender or recipient address might be the user's address, and there is no request-
-                // level sender that the parser already parses this information to.
-                const finalTransaction = transactions![transactions!.length - 1];
-                userAddress = finalTransaction.senderType === Nimiq.AccountType.Basic
-                    ? finalTransaction.sender
-                    : finalTransaction.recipient;
-                // No need to set senderType, as we're not using it for SIGN_STAKING requests.
-            } else {
-                // For SIGN_TRANSACTION the request-level sender is the user's address for all layouts, as the request
-                // parsing binds basic and contract senders to it, and outgoing staking transactions, e.g. remove-stake
-                // of the multi-tx unstaking layout, to pay out to it, see parseSignTransactionRequest.
-                userAddress = sender;
-            }
-
-            // We know that these exist as their existence was already checked in RpcApi.ts
-            const userAccount = this.findWalletByAddress(userAddress.toUserFriendlyAddress(), true)!;
-            const userAccountContract = userAccount.findContractByAddress(userAddress);
-            const userAccountSigner = userAccount.findSignerForAddress(userAddress)!;
-
-            signerKeyId = userAccount.keyId;
-            signerKeyPath = userAccountSigner.path;
-            senderType = sender.equals(userAddress) && userAccountContract
-                ? userAccountContract.type
-                : Nimiq.AccountType.Basic;
-
-            // In the UI, the user can represent the sender (typical case), recipient (for unstaking) or none of those
-            // (for update-staker / switch-validator). If one of those is rendered as the user details, enrich them with
-            // the wallet label and balance.
-            const userAddressDetails = [this.senderDetails, this.recipientDetails]
-                .find(({ address }) => address === userAddress.toUserFriendlyAddress());
-            if (userAddressDetails) {
-                // The label of the user's own address always comes from the user's account data, overwriting a
-                // requested label, which a caller must not be able to set for it.
-                userAddressDetails.label = (userAccountContract || userAccountSigner).label;
-                userAddressDetails.walletLabel = userAddressDetails.walletLabel || userAccount.label;
-                userAddressDetails.balance = userAddressDetails.balance
-                    || (userAccountContract || userAccountSigner).balance;
+            if (stakingValidatorInfo.fromValidatorAddress) {
+                this.senderDetails.address = stakingValidatorInfo.fromValidatorAddress;
+                this.senderDetails.image = stakingValidatorInfo.fromValidatorImageUrl;
             }
         }
 
-        // Collect transaction infos to pass to LedgerApi
-        const transactionInfos: Array<Omit<
-            LedgerApiTransactionInfoNimiq<typeof Config.ledgerApiNimiqVersion>,
-            'senderType' | 'recipientType' | 'validityStartHeight'
-        > & {
-            senderType?: Nimiq.AccountType,
-            recipientType?: Nimiq.AccountType,
-            validityStartHeight?: number,
-        }> = [];
-        if (transactions) { // SIGN_TRANSACTION or SIGN_STAKING request
-            const propertiesToCopy = [
-                'sender',
-                'senderType',
-                'senderData',
-                'recipient',
-                'recipientType',
-                'value',
-                'fee',
-                'validityStartHeight',
-                'flags',
-            ] as const;
-            for (const transaction of transactions) {
-                transactionInfos.push({
-                    ...(propertiesToCopy.reduce((transactionInfo, property) => ({
-                        ...transactionInfo,
-                        [property]: transaction[property],
-                    }), {} as Pick<Nimiq.Transaction, (typeof propertiesToCopy)[number]>)),
-                    recipientData: transaction.data,
-                    network: Config.network as LedgerApiNetwork, // enforce configured network
-                });
-            }
-        } else {
-            transactionInfos.push({
-                sender,
-                senderType,
-                recipient,
-                value: BigInt(value),
-                fee: BigInt(fee || 0),
-                network: Config.network as LedgerApiNetwork,
-                recipientData,
-                flags,
-            });
+        // Refine the display of the user's own address based on the signer info, see userAccountInfo. In the UI, the
+        // user can represent the sender (typical case), recipient (for unstaking) or none of those (for update-staker /
+        // switch-validator). If one of those is rendered as the user details, enrich them with the account's data.
+        const userAddress = this.userAddress;
+        const userAccountInfo = this.userAccountInfo;
+        const userAddressDetails = [this.senderDetails, this.recipientDetails]
+            .find(({ address }) => address === userAddress.toUserFriendlyAddress());
+        if (userAddressDetails) {
+            // The label of the user's own address from the user's account data always takes priority over requested
+            // labels, which a caller must not be able to set for it.
+            userAddressDetails.label = userAccountInfo.label;
+            userAddressDetails.walletLabel = userAccountInfo.walletLabel;
+            userAddressDetails.balance = userAccountInfo.balance;
         }
 
         // Sign transactions, and send to network, depending on the request type.
         const signedTransactions: SignedTransaction[] = [];
-        for (const transactionInfo of transactionInfos) {
+        for (const transaction of transactions) {
             // If user left this view in the meantime, don't continue signing / sending the transactions
             if (this.isDestroyed) return;
 
             // Check whether transaction was already signed but not successfully sent before user reloaded the page.
             let signedTransaction = network.getUnrelayedTransactions({
-                ...transactionInfo,
-                data: transactionInfo.recipientData,
+                sender: transaction.sender,
+                senderType: transaction.senderType,
+                recipient: transaction.recipient,
+                recipientType: transaction.recipientType,
+                value: transaction.value,
+                fee: transaction.fee,
+                flags: transaction.flags,
+                data: transaction.data,
+                // The transactions created by the Hub only get their actual validity start height when they are
+                // signed, so their placeholder height must not be matched, see PLACEHOLDER_VALIDITY_START_HEIGHT.
+                validityStartHeight: isSentByHub ? undefined : transaction.validityStartHeight,
             })[0];
             if (!signedTransaction) {
-                let validityStartHeight = transactionInfo.validityStartHeight;
-                if (validityStartHeight === undefined) {
+                let { validityStartHeight } = transaction;
+                if (isSentByHub) {
                     try {
                         if (!validityStartHeightPromise) throw new Error('Unexpected: no validityStartHeight');
                         validityStartHeight = await validityStartHeightPromise;
@@ -543,16 +473,25 @@ export default class SignTransactionLedger extends Vue {
                     }
                 }
 
+                const transactionInfo: LedgerApiTransactionInfoNimiq<typeof Config.ledgerApiNimiqVersion> = {
+                    sender: transaction.sender,
+                    senderType: transaction.senderType as unknown as LedgerApiAccountTypeNimiq,
+                    senderData: transaction.senderData,
+                    recipient: transaction.recipient,
+                    recipientType: transaction.recipientType as unknown as LedgerApiAccountTypeNimiq,
+                    recipientData: transaction.data,
+                    value: transaction.value,
+                    fee: transaction.fee,
+                    validityStartHeight, // the resolved height for Hub created transactions, never the placeholder
+                    flags: transaction.flags,
+                    network: Config.network as LedgerApiNetwork, // enforce configured network
+                };
+
                 try {
                     signedTransaction = await LedgerApi.Nimiq.signTransaction(
-                        {
-                            ...transactionInfo,
-                            senderType: transactionInfo.senderType as LedgerApiAccountTypeNimiq | undefined,
-                            recipientType: transactionInfo.recipientType as LedgerApiAccountTypeNimiq | undefined,
-                            validityStartHeight,
-                        },
-                        signerKeyPath,
-                        signerKeyId,
+                        transactionInfo,
+                        userAccountInfo.keyPath,
+                        userAccountInfo.keyId,
                         Config.ledgerApiNimiqVersion,
                     );
                 } catch (e) {
@@ -561,14 +500,14 @@ export default class SignTransactionLedger extends Vue {
                     // error message displayed.
                     if (this.state !== SignTransactionLedger.State.EXPIRED
                         && e.message.toLowerCase().indexOf('cancelled') !== -1) {
-                        const isCheckoutRequestWithManuallySelectedAddress = this.request.kind === RequestType.CHECKOUT
+                        const isCheckoutRequestWithManuallySelectedAddress = requestKind === RequestType.CHECKOUT
                             && (
                                 !this.checkoutPaymentOptions!.protocolSpecific.sender
-                                || !sender.equals(this.checkoutPaymentOptions!.protocolSpecific.sender)
+                                || !transaction.sender.equals(this.checkoutPaymentOptions!.protocolSpecific.sender)
                             );
 
                         if (isCheckoutRequestWithManuallySelectedAddress
-                            || this.request.kind === RequestType.CREATE_CASHLINK) {
+                            || requestKind === RequestType.CREATE_CASHLINK) {
                             // If user got here after selecting an account in the checkout flow (which was not
                             // automatically selected via the checkout request) he might want to switch to another one.
                             this._back();
@@ -586,7 +525,7 @@ export default class SignTransactionLedger extends Vue {
             if (this.isDestroyed) return;
 
             // Send transaction to network, depending on the request type, and finish
-            if (this.request.kind === RequestType.CHECKOUT || this.request.kind === RequestType.CREATE_CASHLINK) {
+            if (isSentByHub) {
                 this.state = SignTransactionLedger.State.SENDING_TRANSACTION;
                 if (this.cashlink) {
                     // Store cashlink in database first to be safe when browser crashes during sending
@@ -598,12 +537,12 @@ export default class SignTransactionLedger extends Vue {
             }
         }
 
-        if (this.request.kind !== RequestType.CREATE_CASHLINK) {
+        if (requestKind !== RequestType.CREATE_CASHLINK) {
             this.state = SignTransactionLedger.State.FINISHED;
             await new Promise((resolve) => setTimeout(resolve, StatusScreen.SUCCESS_REDIRECT_DELAY));
             // For SIGN_TRANSACTION, return a single result iff a single transaction was signed (same rule as in
             // the Keyguard); SIGN_STAKING always returns an array
-            const result = this.request.kind !== RequestType.SIGN_STAKING && signedTransactions.length === 1
+            const result = requestKind !== RequestType.SIGN_STAKING && signedTransactions.length === 1
                 ? signedTransactions[0]
                 : signedTransactions;
             this.$rpc.resolve(result);
@@ -619,6 +558,8 @@ export default class SignTransactionLedger extends Vue {
     }
 
     private get checkoutPaymentOptions() {
+        // tslint:disable-next-line no-unused-expression
+        this.requestRevision; // re-evaluate on changes to the request
         if (this.request.kind !== RequestType.CHECKOUT) return null;
         const checkoutRequest = this.request as ParsedCheckoutRequest;
         return checkoutRequest.paymentOptions.find(
@@ -626,20 +567,158 @@ export default class SignTransactionLedger extends Vue {
         ) as ParsedNimiqDirectPaymentOptions;
     }
 
+    private get transactions(): Nimiq.Transaction[] {
+        const transactionsOrError = this.transactionsOrError;
+        return transactionsOrError instanceof Error ? [] : transactionsOrError;
+    }
+
+    private get transactionsError(): Error | null {
+        const transactionsOrError = this.transactionsOrError;
+        return transactionsOrError instanceof Error ? transactionsOrError : null;
+    }
+
     /**
-     * The request's transactions to sign and display, for SIGN_TRANSACTION and SIGN_STAKING requests. Null for other
-     * request types.
+     * The request's transactions to sign and display, or the reason why they can not be built. In error case nothing is
+     * rendered, see the template's root element, and mounted() reports that reason or navigates back. As it's evaluated
+     * during rendering, it must never throw.
      */
-    private get transactions(): Nimiq.Transaction[] | null {
-        switch (this.request.kind) {
-            case RequestType.SIGN_TRANSACTION:
-                return (this.request as ParsedSignTransactionRequest).transactions;
-            case RequestType.SIGN_STAKING:
-                return (this.request as ParsedSignStakingRequest).transactions
-                    .map((plainTransaction) => Nimiq.Transaction.fromPlain(plainTransaction));
-            default:
-                return null;
+    private get transactionsOrError(): Nimiq.Transaction[] | Error {
+        // tslint:disable-next-line no-unused-expression
+        this.requestRevision; // re-evaluate on changes to the request
+        if (this._setupError) return this._setupError;
+        try {
+            let transactions: Nimiq.Transaction[];
+            switch (this.request.kind) {
+                case RequestType.SIGN_TRANSACTION:
+                    // Note that the transactions of legacy requests are patched already in created().
+                    transactions = (this.request as ParsedSignTransactionRequest).transactions;
+                    break;
+                case RequestType.SIGN_STAKING:
+                    transactions = (this.request as ParsedSignStakingRequest).transactions
+                        .map((plainTransaction) => Nimiq.Transaction.fromPlain(plainTransaction));
+                    break;
+                case RequestType.CHECKOUT:
+                case RequestType.CREATE_CASHLINK: {
+                    // The transactions the Hub creates itself, which are transfers from the user's address.
+                    let recipient: Nimiq.Address | undefined;
+                    let recipientType: Nimiq.AccountType | undefined;
+                    let recipientData: Uint8Array | undefined;
+                    let value: number;
+                    let fee: number;
+                    let flags: number | undefined;
+                    if (this.request.kind === RequestType.CHECKOUT) {
+                        const checkoutPaymentOptions = this.checkoutPaymentOptions!;
+                        const { protocolSpecific } = checkoutPaymentOptions;
+                        ({ amount: value, fee } = checkoutPaymentOptions);
+                        ({ recipient, recipientType, extraData: recipientData, flags } = protocolSpecific);
+                    } else {
+                        if (!this.cashlink) {
+                            return new Error('Ledger Cashlink Signing expects the Cashlink to sign to be in the '
+                                + 'static store.'); // see CashlinkCreate
+                        }
+                        ({ recipient, value, fee, recipientData } = this.cashlink.getFundingDetails());
+                    }
+                    // For checkout, the payment info might not include a recipient yet, see mounted.
+                    if (!recipient) return new Error('Failed to fetch checkout recipient.');
+                    transactions = [new Nimiq.Transaction(
+                        this.userAddress, this.userAccountInfo.accountType, /* senderData */ undefined,
+                        recipient, recipientType || Nimiq.AccountType.Basic, recipientData,
+                        BigInt(value), BigInt(fee),
+                        flags || Nimiq.TransactionFlag.None,
+                        PLACEHOLDER_VALIDITY_START_HEIGHT, // the actual validity start height is set when signing
+                        Config.nimiqNetworkId,
+                    )];
+                    break;
+                }
+                default:
+                    return new Error('Ledger Transaction Signing must be invoked via sign-transaction, sign-staking, '
+                        + 'checkout or cashlink requests.');
+            }
+            return transactions.length ? transactions : new Error('Unexpected: no transactions to sign.');
+        } catch (e) {
+            return e instanceof Error ? e : new Error(`Failed to build the transactions to sign: ${e}`);
         }
+    }
+
+    /**
+     * The transaction the request's display is currently based on. Must only be accessed for requests with
+     * transactions, which is the case wherever anything is rendered.
+     */
+    private get finalTransaction(): Nimiq.Transaction {
+        const transactions = this.transactions;
+        return transactions[transactions.length - 1];
+    }
+
+    /**
+     * The user's own address, which can be a regular address or a contract address, and for which the signing key is
+     * resolved, see userAccountInfo. Depending on the request type and the transactions, it can be rendered as the
+     * sender (typical case), as the recipient (for unstaking) or not at all (for update-staker / switch-validator).
+     */
+    private get userAddress(): Nimiq.Address {
+        switch (this.request.kind) {
+            case RequestType.SIGN_TRANSACTION: {
+                // The request-level sender is the user's address for all layouts, as the request parsing binds basic
+                // and contract senders to it, and outgoing staking transactions, e.g. remove-stake of the multi-tx
+                // unstaking layout, to pay out to it, see parseSignTransactionRequest.
+                const { sender } = this.request as ParsedSignTransactionRequest;
+                return sender instanceof Nimiq.Address ? sender : sender.address;
+            }
+            case RequestType.SIGN_STAKING: {
+                // For staking, the sender or recipient address might be the user's address, and there is no request-
+                // level sender that the parser already parses this information to.
+                const finalTransaction = this.finalTransaction;
+                return finalTransaction.senderType === Nimiq.AccountType.Basic
+                    ? finalTransaction.sender
+                    : finalTransaction.recipient;
+            }
+            case RequestType.CHECKOUT:
+            case RequestType.CREATE_CASHLINK:
+                // For checkout and cashlink requests, the user chose the address to pay from, see CheckoutCardNimiq
+                // and CashlinkCreate, which set it as the active address.
+                return Nimiq.Address.fromString(this.$store.state.activeUserFriendlyAddress);
+            default:
+                throw new Error(`Unsupported request type: ${(this.request as { kind: string }).kind}`);
+        }
+    }
+
+    /**
+     * The key to sign the request's transactions with, the type of the user's address, and the data to display for it.
+     * For SIGN_TRANSACTION requests with a sender info object, currently only for internal use in RefundSwapLedger,
+     * this info comes from that object; for all other requests it is resolved from the WalletStore.
+     */
+    private get userAccountInfo(): UserAccountInfo {
+        // Check the request kind explicitly. `'sender' in this.request` would be a structural check, which also
+        // passes for a sender property smuggled into a sign-staking request, the parsing of which passes unknown
+        // properties through, see RequestParser. A caller must not be able to provide the signer key or the labels
+        // for the user's own address.
+        const requestSender = this.request.kind === RequestType.SIGN_TRANSACTION
+            ? (this.request as ParsedSignTransactionRequest).sender
+            : undefined;
+        if (requestSender && !(requestSender instanceof Nimiq.Address)) {
+            // Internal sender information passed from RefundSwapLedger
+            const { type, label, walletLabel, signerKeyId, signerKeyPath } = requestSender;
+            return {
+                keyId: signerKeyId,
+                keyPath: signerKeyPath,
+                accountType: type || Nimiq.AccountType.Basic,
+                label,
+                walletLabel,
+            };
+        }
+
+        const userAddress = this.userAddress;
+        // We know that these exist as their existence was already checked in RpcApi.ts
+        const userAccount = this.findWalletByAddress(userAddress.toUserFriendlyAddress(), true)!;
+        const userAccountContract = userAccount.findContractByAddress(userAddress);
+        const userAccountSigner = userAccount.findSignerForAddress(userAddress)!;
+        return {
+            keyId: userAccount.keyId,
+            keyPath: userAccountSigner.path,
+            accountType: userAccountContract ? userAccountContract.type : Nimiq.AccountType.Basic,
+            label: (userAccountContract || userAccountSigner).label,
+            walletLabel: userAccount.label,
+            balance: (userAccountContract || userAccountSigner).balance,
+        };
     }
 
     /**
@@ -682,9 +761,7 @@ export default class SignTransactionLedger extends Vue {
         // Only for update-staker, the sender is rendered as the old validator instead of as the user's address (the
         // actual sender). Don't provide the from-validator info for other transactions, regardless of the request's
         // info, which is not thoroughly validated against the transactions for SIGN_STAKING requests.
-        const transactions = this.transactions!;
-        const finalTransaction = transactions[transactions.length - 1];
-        if (finalTransaction.toPlain().data.type !== 'update-staker') {
+        if (this.finalTransaction.toPlain().data.type !== 'update-staker') {
             validatorInfo.fromValidatorAddress = undefined;
             validatorInfo.fromValidatorImageUrl = undefined;
         }
@@ -692,21 +769,12 @@ export default class SignTransactionLedger extends Vue {
     }
 
     private get amountAndFee() {
-        let amount: number;
-        let fee: number;
-        if (this.checkoutPaymentOptions) {
-            ({ amount, fee } = this.checkoutPaymentOptions);
-        } else if (this.cashlink) {
-            ({ value: amount, fee } = this.cashlink);
-        } else { // SIGN_TRANSACTION or SIGN_STAKING request
-            // Display the value of the final transaction, and the fees of all transactions. For a standard layout
-            // SIGN_TRANSACTION request, this is the single transaction's value and fee.
-            const transactions = this.transactions!;
-            const finalTransaction = transactions[transactions.length - 1];
-            amount = Number(finalTransaction.value);
-            fee = transactions.reduce((sum, transaction) => sum + Number(transaction.fee), 0);
-        }
-        return { amount, fee };
+        // Display the value of the final transaction currently, and the fees of all transactions. For requests with a
+        // single transaction, this is that transaction's value and fee.
+        return {
+            amount: Number(this.finalTransaction.value),
+            fee: this.transactions.reduce((sum, transaction) => sum + Number(transaction.fee), 0),
+        };
     }
 
     private get transactionData() {
@@ -718,19 +786,9 @@ export default class SignTransactionLedger extends Vue {
         const stakingData = this.stakingData;
         if (stakingData) return stakingData;
 
-        let data;
-        let flags;
-        if (this.request.kind === RequestType.SIGN_TRANSACTION) {
-            // Standard layout with a single, non-staking transaction. Multiple transactions are rejected in mounted(),
-            // and staking transactions, including the staking layouts, are handled via stakingData above.
-            const [transaction] = (this.request as ParsedSignTransactionRequest).transactions;
-            data = transaction.data;
-            flags = transaction.flags;
-        } else if (this.request.kind === RequestType.CHECKOUT) {
-            ({ extraData: data, flags } = this.checkoutPaymentOptions!.protocolSpecific);
-        } else { // SIGN_STAKING request without staking info; not expected to happen
-            return null;
-        }
+        // Non-staking transactions. For SIGN_TRANSACTION requests, this is the single transaction of the standard
+        // layout; multiple transactions are rejected in mounted.
+        const { data, flags } = this.finalTransaction;
 
         if (!data || data.length === 0) {
             return null;
@@ -750,10 +808,8 @@ export default class SignTransactionLedger extends Vue {
     private get stakingData() {
         // Staking data for SIGN_STAKING and SIGN_TRANSACTION requests whose final transaction is a staking transaction,
         // e.g. of the switch-validator or unstaking layouts, or a single staking transaction on the standard layout.
-        const transactions = this.transactions;
-        if (!transactions) return null;
         // Display data based on final transaction.
-        const finalTransaction = transactions[transactions.length - 1];
+        const finalTransaction = this.finalTransaction;
         const isIncomingStakingTransaction = finalTransaction.recipientType === Nimiq.AccountType.Staking;
         const isOutgoingStakingTransaction = finalTransaction.senderType === Nimiq.AccountType.Staking;
         if (!isIncomingStakingTransaction && !isOutgoingStakingTransaction) return null;

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -76,7 +76,7 @@
             </div>
 
             <div class="bottom-container blur-target" :class="{ 'full-height': state !== constructor.State.OVERVIEW }">
-                <LedgerUi ref="ledger-ui" small></LedgerUi>
+                <LedgerUi ref="ledger-ui" small :signingStep="signingStep"></LedgerUi>
                 <transition name="transition-fade">
                     <StatusScreen v-if="state !== constructor.State.OVERVIEW"
                         :state="statusScreenState"
@@ -232,6 +232,7 @@ export default class SignTransactionLedger extends Vue {
     private recipientDetails: AccountDetailsData = { address: '' };
     private shownAccountDetails: AccountDetailsData | null = null;
     private isDestroyed: boolean = false;
+    private currentlySignedTransactionIndex: number = 0;
     // Counter to be incremented after in-place changes to the request, which is not reactive itself, to re-evaluate
     // the getters that are based on it, see transactions getter.
     private requestRevision: number = 0;
@@ -442,7 +443,13 @@ export default class SignTransactionLedger extends Vue {
 
         // Sign transactions, and send to network, depending on the request type.
         const signedTransactions: SignedTransaction[] = [];
-        for (const transaction of transactions) {
+        for (
+            this.currentlySignedTransactionIndex = 0;
+            this.currentlySignedTransactionIndex < transactions.length;
+            this.currentlySignedTransactionIndex++
+        ) {
+            const transaction = transactions[this.currentlySignedTransactionIndex];
+
             // If user left this view in the meantime, don't continue signing / sending the transactions
             if (this.isDestroyed) return;
 
@@ -815,7 +822,10 @@ export default class SignTransactionLedger extends Vue {
         if (!isIncomingStakingTransaction && !isOutgoingStakingTransaction) return null;
         // Decode the staking data, which is the recipient data for incoming and the sender data for outgoing staking
         // transactions, into its plain form.
-        const { sender, senderData, data: recipientData } = finalTransaction.toPlain();
+        const plainTransaction = finalTransaction.toPlain();
+        const { sender, data: recipientData } = plainTransaction;
+        // The senderData is typed as optional, but is always set, also for non-staking senders, for which it's raw.
+        const senderData = plainTransaction.senderData!;
 
         if (isIncomingStakingTransaction) {
             switch (recipientData.type) {
@@ -902,7 +912,6 @@ export default class SignTransactionLedger extends Vue {
                 }
             }
         } else { // outgoing staking transaction
-            // @ts-ignore Missmatch with Nimiq.PlainTransactionDetails from fastspot-api
             switch (senderData.type) {
                 case 'remove-stake': {
                     return 'Unstake';
@@ -912,11 +921,54 @@ export default class SignTransactionLedger extends Vue {
                     return 'Delete validator';
                 }
                 default: {
-                    // @ts-ignore Missmatch with Nimiq.PlainTransactionDetails from fastspot-api
                     return `Unrecognized outgoing staking data: ${senderData.type} - ${senderData.raw}`;
                 }
             }
         }
+    }
+
+    /**
+     * Info about the transaction of a multi-transaction flow that is currently being signed, to be displayed as a step
+     * indicator in the LedgerUi.
+     */
+    private get signingStep(): LedgerUi.SigningStep | null {
+        const transactions = this.transactions;
+        if (transactions.length <= 1) return null; // not a multi-transaction flow
+        const index = Math.min(this.currentlySignedTransactionIndex, transactions.length - 1);
+        const transaction = transactions[index];
+
+        const { data: recipientData, senderData } = transaction.toPlain();
+        let stakingDataType: string | undefined;
+        if (transaction.recipientType === Nimiq.AccountType.Staking) {
+            stakingDataType = recipientData.type;
+        } else if (transaction.senderType === Nimiq.AccountType.Staking && senderData) {
+            stakingDataType = senderData.type;
+        }
+
+        // Provide instructions for the currently supported multi-transaction flows.
+        let instructions: string;
+        switch (stakingDataType) {
+            case 'set-active-stake':
+                instructions = this.$t('Confirm setting active stake amount') as string;
+                break;
+            case 'update-staker':
+                instructions = this.$t('Confirm update of staking setup') as string;
+                break;
+            case 'retire-stake':
+                instructions = this.$t('Confirm retiring staked NIM') as string;
+                break;
+            case 'remove-stake':
+                instructions = this.$t('Confirm withdrawal of retired NIM') as string;
+                break;
+            default:
+                instructions = this.$t('Confirm Transaction') as string;
+        }
+
+        return {
+            step: index + 1, // step is 1-based.
+            totalSteps: transactions.length,
+            instructions,
+        };
     }
 
     private get statusScreenState() {

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -105,7 +105,6 @@
 
         <GlobalClose :buttonLabel="request.kind === 'checkout' ? $t('Cancel payment') : '' /* use default */"
             :onClose="_close" :hidden="state !== constructor.State.OVERVIEW" />
-        <Network ref="network" />
     </div>
 </template>
 
@@ -203,7 +202,6 @@ interface StakingValidatorInfo {
     StatusScreen,
     GlobalClose,
     AccountDetails,
-    Network,
     Amount,
     ArrowRightIcon,
     StopwatchIcon,
@@ -231,6 +229,10 @@ export default class SignTransactionLedger extends Vue {
     private shownAccountDetails: AccountDetailsData | null = null;
     private isDestroyed: boolean = false;
     private currentlySignedTransactionIndex: number = 0;
+    // The Network component does not render anything and is therefore instantiated manually, instead of being part of
+    // the template, where it would not be available while the transactions could not be built yet, for example for a
+    // checkout with a recipient that still has to be recovered after a reload, see transactionsOrError.
+    private network: Network = new Network();
     // Counter to be incremented after in-place changes to the request, which is not reactive itself, to re-evaluate
     // the getters that are based on it, see transactions getter.
     private requestRevision: number = 0;
@@ -298,7 +300,7 @@ export default class SignTransactionLedger extends Vue {
             }
         }
 
-        const network = this.$refs.network as Network;
+        const { network } = this;
         if (isSentByHub) {
             // Pre-connect to network when we know we'll need it. Does not need to be awaited, as the methods on network
             // that actually need to be connected, themselves ensure to be connected.
@@ -551,6 +553,7 @@ export default class SignTransactionLedger extends Vue {
         this.isDestroyed = true;
         clearTimeout(this._checkoutExpiryTimeout);
         this._cancelLedgerRequest();
+        this.network.$destroy(); // as it's not a rendered child component, it has to be destroyed manually
     }
 
     /**

--- a/src/views/SignTransactionLedger.vue
+++ b/src/views/SignTransactionLedger.vue
@@ -142,8 +142,10 @@ import {
     ParsedSignStakingRequest,
     ParsedCreateCashlinkRequest,
     ParsedCheckoutRequest,
+    SignTransactionRequestLayout,
 } from '../lib/RequestTypes';
 import { Currency, RequestType, SignedTransaction } from '../../client/PublicRequestTypes';
+import { patchLegacyRequestSenderType } from '../lib/SignTransactionRequestParsing';
 import { WalletInfo } from '../lib/WalletInfo';
 import {
     CASHLINK_FUNDING_DATA,
@@ -208,6 +210,18 @@ export default class SignTransactionLedger extends Vue {
     private _checkoutExpiryTimeout: number = -1;
 
     private async mounted() {
+        if (this.request.kind === RequestType.SIGN_TRANSACTION) {
+            const signTransactionRequest = this.request as ParsedSignTransactionRequest;
+            if (signTransactionRequest.layout !== SignTransactionRequestLayout.STANDARD
+                || signTransactionRequest.transactions.length > 1) {
+                // Multi-transaction requests and the staking layouts are not supported for Ledger accounts yet.
+                // Ledger staking flows currently go through SIGN_STAKING requests instead.
+                this.$rpc.reject(new Error(
+                    'Multi-transaction sign-transaction requests are not yet supported for Ledger accounts'));
+                return;
+            }
+        }
+
         const network = this.$refs.network as Network;
         if (this.request.kind === RequestType.CHECKOUT || this.request.kind === RequestType.CREATE_CASHLINK) {
             // Pre-connect to network when we know we'll need it. Does not need to be awaited, as the methods on network
@@ -228,21 +242,35 @@ export default class SignTransactionLedger extends Vue {
         let recipient: Nimiq.Address;
         let value: number;
         let fee: number;
-        let validityStartHeightPromise: Promise<number>;
+        let validityStartHeightPromise: Promise<number> | undefined;
         let recipientData: Uint8Array | undefined;
         let flags: number;
         if (this.request.kind === RequestType.SIGN_TRANSACTION) {
             // Direct sign transaction request invocation
             const signTransactionRequest = this.request as ParsedSignTransactionRequest;
-            ({ recipient, value, fee, data: recipientData, flags } = signTransactionRequest);
             sender = signTransactionRequest.sender instanceof Nimiq.Address
                 ? signTransactionRequest.sender
                 : signTransactionRequest.sender.address;
-            validityStartHeightPromise = Promise.resolve(signTransactionRequest.validityStartHeight);
 
-            const recipientUserFriendlyAddress = signTransactionRequest.recipient.toUserFriendlyAddress();
+            // The legacy single-transaction request format does not support specifying the senderType, in which case
+            // it is determined from the WalletStore.
+            let storeSenderType = Nimiq.AccountType.Basic;
+            if (!(signTransactionRequest.sender instanceof Nimiq.Address)) {
+                storeSenderType = signTransactionRequest.sender.type || Nimiq.AccountType.Basic;
+            } else {
+                // existence checked in RpcApi
+                const senderContract = this.findWalletByAddress(sender.toUserFriendlyAddress(), true)!
+                    .findContractByAddress(sender);
+                if (senderContract) storeSenderType = senderContract.type;
+            }
+            patchLegacyRequestSenderType(signTransactionRequest, storeSenderType);
+
+            // Set other values only for correct type checking. They won't be used for request type SIGN_TRANSACTION.
+            recipient = sender;
+            value = fee = flags = Number.NaN;
+
             this.recipientDetails = {
-                address: recipientUserFriendlyAddress,
+                address: signTransactionRequest.transactions[0].recipient.toUserFriendlyAddress(),
                 label: signTransactionRequest.recipientLabel,
             };
         } else if (this.request.kind === RequestType.SIGN_STAKING) {
@@ -256,7 +284,6 @@ export default class SignTransactionLedger extends Vue {
             // Set other values only for correct type checking. They won't be used for request type SIGN_STAKING.
             recipient = sender;
             value = fee = flags = Number.NaN;
-            validityStartHeightPromise = Promise.reject();
 
             this.recipientDetails = {
                 address: finalTransaction.recipient,
@@ -426,7 +453,33 @@ export default class SignTransactionLedger extends Vue {
             recipientType?: Nimiq.AccountType,
             validityStartHeight?: number,
         }> = [];
-        if (this.request.kind !== RequestType.SIGN_STAKING) {
+        if (this.request.kind === RequestType.SIGN_TRANSACTION || this.request.kind === RequestType.SIGN_STAKING) {
+            const transactions = this.request.kind === RequestType.SIGN_TRANSACTION
+                ? (this.request as ParsedSignTransactionRequest).transactions
+                : (this.request as ParsedSignStakingRequest).transactions
+                    .map((plainTransaction) => Nimiq.Transaction.fromPlain(plainTransaction));
+            const propertiesToCopy = [
+                'sender',
+                'senderType',
+                'senderData',
+                'recipient',
+                'recipientType',
+                'value',
+                'fee',
+                'validityStartHeight',
+                'flags',
+            ] as const;
+            for (const transaction of transactions) {
+                transactionInfos.push({
+                    ...(propertiesToCopy.reduce((transactionInfo, property) => ({
+                        ...transactionInfo,
+                        [property]: transaction[property],
+                    }), {} as Pick<Nimiq.Transaction, (typeof propertiesToCopy)[number]>)),
+                    recipientData: transaction.data,
+                    network: Config.network as LedgerApiNetwork, // enforce configured network
+                });
+            }
+        } else {
             transactionInfos.push({
                 sender,
                 senderType,
@@ -437,30 +490,6 @@ export default class SignTransactionLedger extends Vue {
                 recipientData,
                 flags,
             });
-        } else {
-            const signStakingRequest = this.request as ParsedSignStakingRequest;
-            for (const plainTransaction of signStakingRequest.transactions) {
-                const transaction = Nimiq.Transaction.fromPlain(plainTransaction);
-                const propertiesToCopy = [
-                    'sender',
-                    'senderType',
-                    'senderData',
-                    'recipient',
-                    'recipientType',
-                    'value',
-                    'fee',
-                    'validityStartHeight',
-                    'flags',
-                ] as const;
-                transactionInfos.push({
-                    ...(propertiesToCopy.reduce((transactionInfo, property) => ({
-                        ...transactionInfo,
-                        [property]: transaction[property],
-                    }), {} as Pick<Nimiq.Transaction, (typeof propertiesToCopy)[number]>)),
-                    recipientData: transaction.data,
-                    network: Config.network as LedgerApiNetwork, // enforce configured network
-                });
-            }
         }
 
         // Sign transactions, and send to network, depending on the request type.
@@ -476,8 +505,9 @@ export default class SignTransactionLedger extends Vue {
             })[0];
             if (!signedTransaction) {
                 let validityStartHeight = transactionInfo.validityStartHeight;
-                if (!validityStartHeight) {
+                if (validityStartHeight === undefined) {
                     try {
+                        if (!validityStartHeightPromise) throw new Error('Unexpected: no validityStartHeight');
                         validityStartHeight = await validityStartHeightPromise;
                     } catch (e) {
                         if (this.isDestroyed) return; // user is not on this view anymore
@@ -544,7 +574,11 @@ export default class SignTransactionLedger extends Vue {
         if (this.request.kind !== RequestType.CREATE_CASHLINK) {
             this.state = SignTransactionLedger.State.FINISHED;
             await new Promise((resolve) => setTimeout(resolve, StatusScreen.SUCCESS_REDIRECT_DELAY));
-            const result = this.request.kind !== RequestType.SIGN_STAKING ? signedTransactions[0] : signedTransactions;
+            // For SIGN_TRANSACTION, return a single result iff a single transaction was signed (same rule as in
+            // the Keyguard); SIGN_STAKING always returns an array
+            const result = this.request.kind !== RequestType.SIGN_STAKING && signedTransactions.length === 1
+                ? signedTransactions[0]
+                : signedTransactions;
             this.$rpc.resolve(result);
         } else {
             this.$router.replace({ name: RequestType.MANAGE_CASHLINK });
@@ -572,8 +606,10 @@ export default class SignTransactionLedger extends Vue {
             ({ amount, fee } = this.checkoutPaymentOptions);
         } else if (this.cashlink) {
             ({ value: amount, fee } = this.cashlink);
-        } else if ('value' in this.request && 'fee' in this.request) { // SIGN_TRANSACTION request
-            ({ value: amount, fee } = this.request);
+        } else if (this.request.kind === RequestType.SIGN_TRANSACTION) {
+            const { transactions } = this.request as ParsedSignTransactionRequest;
+            amount = Number(transactions[0].value);
+            fee = Number(transactions[0].fee);
         } else { // SIGN_STAKING request
             const { transactions } = this.request as ParsedSignStakingRequest;
             const finalTransaction = transactions[transactions.length - 1];
@@ -595,7 +631,9 @@ export default class SignTransactionLedger extends Vue {
         let data;
         let flags;
         if (this.request.kind === RequestType.SIGN_TRANSACTION) {
-            ({ data, flags } = this.request as ParsedSignTransactionRequest);
+            const [transaction] = (this.request as ParsedSignTransactionRequest).transactions;
+            data = transaction.data;
+            flags = transaction.flags;
         } else { // Checkout
             ({ extraData: data, flags } = this.checkoutPaymentOptions!.protocolSpecific);
         }

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -1,20 +1,27 @@
+<template></template>
+
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { SignedTransaction } from '../../client/PublicRequestTypes';
 import { State } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 
-@Component({})
-export default class SignTransactionSuccess extends Vue {
-    @State private keyguardResult!: KeyguardClient.SignTransactionResult;
+// Type guard to check if result is an array
+function isMultiTransactionResult(
+    result: KeyguardClient.SignTransactionResult | KeyguardClient.SignTransactionResult[],
+): result is KeyguardClient.SignTransactionResult[] {
+    return Array.isArray(result);
+}
 
-    private mounted() {
-        const hex = Nimiq.BufferUtils.toHex(this.keyguardResult.serializedTx);
-        const tx = Nimiq.Transaction.fromAny(hex);
+function convertToSignedTransaction(txResult: KeyguardClient.SignTransactionResult): SignedTransaction {
+    const hex = Nimiq.BufferUtils.toHex(txResult.serializedTx);
+    const tx = Nimiq.Transaction.fromAny(hex);
+
+    try {
         const plain = tx.toPlain();
 
-        const result: SignedTransaction = {
-            transaction: this.keyguardResult.serializedTx,
+        return {
+            transaction: txResult.serializedTx,
             serializedTx: hex,
             hash: plain.transactionHash,
             raw: {
@@ -36,8 +43,48 @@ export default class SignTransactionSuccess extends Vue {
                 networkId: tx.networkId,
             },
         };
+    } catch (error) {
+        // Handle case where toPlain() fails (e.g., for demo/invalid transactions)
+        // Still return the signed transaction data even if we can't parse all details
+        console.warn('Failed to parse transaction details:', error);
+        return {
+            transaction: txResult.serializedTx,
+            serializedTx: hex,
+            hash: '', // Will be empty for invalid transactions
+            raw: {
+                sender: '',
+                senderType: tx.senderType,
+                recipient: '',
+                recipientType: tx.recipientType,
+                value: 0,
+                fee: 0,
+                validityStartHeight: 0,
+                networkId: 0,
+                flags: 0,
+                proof: tx.proof,
+                signerPublicKey: new Uint8Array(0),
+                signature: new Uint8Array(0),
+                extraData: tx.data,
+            },
+        };
+    }
+}
 
-        this.$rpc.resolve(result);
+@Component({})
+export default class SignTransactionSuccess extends Vue {
+    @State private keyguardResult!: KeyguardClient.SignTransactionResult | KeyguardClient.SignTransactionResult[];
+
+    private mounted() {
+        // Handle both single and multi-transaction results
+        if (isMultiTransactionResult(this.keyguardResult)) {
+            // Multi-transaction result
+            const results: SignedTransaction[] = this.keyguardResult.map(convertToSignedTransaction);
+            this.$rpc.resolve(results);
+        } else {
+            // Single transaction result (backward compatible)
+            const result: SignedTransaction = convertToSignedTransaction(this.keyguardResult);
+            this.$rpc.resolve(result);
+        }
     }
 }
 </script>

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,6 +1,18 @@
-// jsdom does not provide TextEncoder/TextDecoder, which the wasm-bindgen glue of @nimiq/core
-// requires at module load time.
-const { TextEncoder, TextDecoder } = require('util');
+// The jsdom test environment does not provide TextEncoder / TextDecoder, which @nimiq/core's nodejs WASM build
+// requires as globals. Provide them from node's util module.
+// Note that node's TextEncoder creates Uint8Arrays in node's realm, which are not instanceof the Uint8Array of the
+// test context's realm, which would make instanceof checks in the tested code behave differently than in a browser.
+// They are therefore re-created in the test context's realm.
+const { TextEncoder: NodeTextEncoder, TextDecoder: NodeTextDecoder } = require('util');
 
-if (typeof global.TextEncoder === 'undefined') global.TextEncoder = TextEncoder;
-if (typeof global.TextDecoder === 'undefined') global.TextDecoder = TextDecoder;
+if (typeof globalThis.TextEncoder === 'undefined') {
+    globalThis.TextEncoder = class TextEncoder extends NodeTextEncoder {
+        encode(input) {
+            return Uint8Array.from(super.encode(input));
+        }
+    };
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+    // Decoding returns a string, i.e. no realm specific instances involved.
+    globalThis.TextDecoder = NodeTextDecoder;
+}

--- a/tests/unit/SignTransactionRequestParsing.spec.ts
+++ b/tests/unit/SignTransactionRequestParsing.spec.ts
@@ -1,0 +1,1020 @@
+import { setup } from './_setup';
+import Config from 'config';
+import {
+    parseSignTransactionRequest,
+    patchLegacyRequestSenderType,
+    rawSignTransactionRequest,
+} from '@/lib/SignTransactionRequestParsing';
+import type { ParsedSignTransactionRequest } from '@/lib/RequestTypes';
+import type { SignTransactionRequest } from '../../client/PublicRequestTypes';
+
+setup();
+
+// These tests pin the SIGN_TRANSACTION request validation, which is a port of the Keyguard's reviewed
+// implementation (see SignTransactionRequestParsing.ts). Note that the Keyguard itself has no tests for its
+// parsing, such that this is the only test coverage of these checks.
+
+const APP_NAME = 'Test App';
+const SENDER = 'NQ73 822X Q55C EQ9N BV36 DD59 TMED X511 TQAY';
+const RECIPIENT = 'NQ63 U7XG 1YYE D6FA SXGG 3F5H X403 NBKN JLDU';
+const OTHER = 'NQ46 2RM7 QE4T 82KR 61Q9 9B7E R38G LBVM N6KY';
+const VALIDATOR = 'NQ70 APBA 9GCC FL44 D82R UJCD DS4B Y824 3LYJ';
+const FROM_VALIDATOR = 'NQ94 DA1Q SVB4 61YN XEY6 2TVT F22G 0381 L284';
+const VALIDITY_START_HEIGHT = 1000;
+
+const networkId = () => Config.nimiqNetworkId;
+const address = (userFriendly: string) => Nimiq.Address.fromString(userFriendly);
+const epoch = () => Nimiq.Policy.BLOCKS_PER_EPOCH;
+
+function basicTx(sender: string = SENDER, recipient: string = RECIPIENT, validityStartHeight?: number, netId?: number) {
+    return Nimiq.TransactionBuilder.newBasic(
+        address(sender),
+        address(recipient),
+        BigInt(100000),
+        BigInt(0),
+        validityStartHeight !== undefined ? validityStartHeight : VALIDITY_START_HEIGHT,
+        netId !== undefined ? netId : networkId(),
+    );
+}
+
+function switchValidatorTxs(options: {
+    updateStakerSender?: string,
+    updateStakerDelay?: number,
+    newActiveBalance?: bigint,
+    newDelegation?: Nimiq.Address,
+    reactivateAllStake?: boolean,
+} = {}): [Nimiq.Transaction, Nimiq.Transaction] {
+    const setActiveStakeTx = Nimiq.TransactionBuilder.newSetActiveStake(
+        address(SENDER),
+        options.newActiveBalance !== undefined ? options.newActiveBalance : BigInt(0),
+        BigInt(0),
+        VALIDITY_START_HEIGHT,
+        networkId(),
+    );
+    const updateStakerTx = Nimiq.TransactionBuilder.newUpdateStaker(
+        address(options.updateStakerSender || SENDER),
+        'newDelegation' in options ? options.newDelegation : address(VALIDATOR),
+        options.reactivateAllStake !== undefined ? options.reactivateAllStake : true,
+        BigInt(0),
+        VALIDITY_START_HEIGHT + (options.updateStakerDelay !== undefined ? options.updateStakerDelay : epoch() + 1),
+        networkId(),
+    );
+    return [setActiveStakeTx, updateStakerTx];
+}
+
+function switchValidatorRequest(
+    transactions: Array<Nimiq.Transaction | Uint8Array>,
+    extraFields: object = {},
+): SignTransactionRequest {
+    return {
+        appName: APP_NAME,
+        sender: SENDER,
+        layout: 'switch-validator',
+        transactions: transactions.map((tx) => tx instanceof Uint8Array ? tx : tx.serialize()),
+        fromValidatorAddress: FROM_VALIDATOR,
+        ...extraFields,
+    } as SignTransactionRequest;
+}
+
+function unstakingTxs(options: {
+    retireStake?: bigint,
+    retireStakeDelay?: number,
+    removeStake?: Nimiq.Transaction,
+    removeStakeRecipient?: string,
+    removeStakeDelayAfterRetire?: number,
+} = {}): [Nimiq.Transaction, Nimiq.Transaction, Nimiq.Transaction] {
+    const amount = BigInt(100000);
+    const retireStakeDelay = options.retireStakeDelay !== undefined ? options.retireStakeDelay : epoch() + 1;
+    const setActiveStakeTx = Nimiq.TransactionBuilder.newSetActiveStake(
+        address(SENDER),
+        BigInt(0),
+        BigInt(0),
+        VALIDITY_START_HEIGHT,
+        networkId(),
+    );
+    const retireStakeTx = Nimiq.TransactionBuilder.newRetireStake(
+        address(SENDER),
+        options.retireStake !== undefined ? options.retireStake : amount,
+        BigInt(0),
+        VALIDITY_START_HEIGHT + retireStakeDelay,
+        networkId(),
+    );
+    const removeStakeTx = options.removeStake || Nimiq.TransactionBuilder.newRemoveStake(
+        address(options.removeStakeRecipient || SENDER),
+        amount,
+        BigInt(0),
+        VALIDITY_START_HEIGHT + retireStakeDelay
+            + (options.removeStakeDelayAfterRetire !== undefined ? options.removeStakeDelayAfterRetire : 1),
+        networkId(),
+    );
+    return [setActiveStakeTx, retireStakeTx, removeStakeTx];
+}
+
+function unstakingRequest(
+    transactions: Nimiq.Transaction[],
+    extraFields: object = {},
+): SignTransactionRequest {
+    return {
+        appName: APP_NAME,
+        sender: SENDER,
+        layout: 'unstaking',
+        transactions: transactions.map((tx) => tx.serialize()),
+        validatorAddress: VALIDATOR,
+        ...extraFields,
+    } as SignTransactionRequest;
+}
+
+function payoutToUserTx(recipient: string = SENDER, amount: bigint = BigInt(100000)) {
+    return Nimiq.TransactionBuilder.newRemoveStake(
+        address(recipient),
+        amount,
+        BigInt(0),
+        VALIDITY_START_HEIGHT,
+        networkId(),
+    );
+}
+
+// Re-creates an incoming staking transaction with a contract sender at the same address. Note that such a transaction
+// passes the request-level sender binding, which compares the sender address and not its type.
+function withContractSender(tx: Nimiq.Transaction) {
+    return new Nimiq.Transaction(
+        tx.sender, Nimiq.AccountType.Vesting, tx.senderData,
+        tx.recipient, tx.recipientType, tx.data,
+        tx.value, tx.fee, tx.flags, tx.validityStartHeight, networkId(),
+    );
+}
+
+function expectParsedEqual(actual: ParsedSignTransactionRequest, expected: ParsedSignTransactionRequest) {
+    expect(actual.kind).toBe(expected.kind);
+    expect(actual.appName).toBe(expected.appName);
+    expect(actual.layout).toBe(expected.layout);
+    expect((actual.sender as Nimiq.Address).toUserFriendlyAddress())
+        .toBe((expected.sender as Nimiq.Address).toUserFriendlyAddress());
+    expect(actual.transactions.map((tx) => Array.from(tx.serialize())))
+        .toEqual(expected.transactions.map((tx) => Array.from(tx.serialize())));
+    expect(actual.senderLabel).toBe(expected.senderLabel);
+    expect(actual.recipientLabel).toBe(expected.recipientLabel);
+    expect(actual.validatorAddress && actual.validatorAddress.toUserFriendlyAddress())
+        .toBe(expected.validatorAddress && expected.validatorAddress.toUserFriendlyAddress());
+    expect(actual.validatorImageUrl && actual.validatorImageUrl.toString())
+        .toBe(expected.validatorImageUrl && expected.validatorImageUrl.toString());
+    expect(actual.fromValidatorAddress && actual.fromValidatorAddress.toUserFriendlyAddress())
+        .toBe(expected.fromValidatorAddress && expected.fromValidatorAddress.toUserFriendlyAddress());
+    expect(actual.fromValidatorImageUrl && actual.fromValidatorImageUrl.toString())
+        .toBe(expected.fromValidatorImageUrl && expected.fromValidatorImageUrl.toString());
+}
+
+describe('SignTransactionRequestParsing', () => {
+    describe('request structure and layout', () => {
+        it('parses a legacy single-transaction request into a one-element transactions array', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                recipient: RECIPIENT,
+                recipientLabel: 'Alice',
+                value: 12345,
+                fee: 7,
+                extraData: 'hello',
+                validityStartHeight: VALIDITY_START_HEIGHT,
+            });
+            expect(parsed.layout).toBe('standard');
+            expect(parsed.transactions.length).toBe(1);
+            const [tx] = parsed.transactions;
+            expect(tx.sender.toUserFriendlyAddress()).toBe(SENDER);
+            expect(tx.senderType).toBe(Nimiq.AccountType.Basic);
+            expect(tx.recipient.toUserFriendlyAddress()).toBe(RECIPIENT);
+            expect(tx.value).toBe(BigInt(12345));
+            expect(tx.fee).toBe(BigInt(7));
+            expect(Array.from(tx.data)).toEqual([104, 101, 108, 108, 111]); // 'hello' in utf8
+            expect(tx.validityStartHeight).toBe(VALIDITY_START_HEIGHT);
+            expect(parsed.recipientLabel).toBe('Alice');
+        });
+
+        it('accepts a validityStartHeight of 0', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                recipient: RECIPIENT,
+                value: 12345,
+                validityStartHeight: 0,
+            });
+            expect(parsed.transactions[0].validityStartHeight).toBe(0);
+        });
+
+        it('rejects non-array and empty transactions', () => {
+            const base = { appName: APP_NAME, sender: SENDER };
+            expect(() => parseSignTransactionRequest(
+                { ...base, transactions: 'foo' } as any as SignTransactionRequest,
+            )).toThrow('transactions must be an array');
+            expect(() => parseSignTransactionRequest(
+                { ...base, transactions: [] } as any as SignTransactionRequest,
+            )).toThrow('transactions array must not be empty');
+        });
+
+        it('rejects invalid layouts', () => {
+            for (const layout of ['checkout', 'cashlink', 'garbage']) {
+                expect(() => parseSignTransactionRequest({
+                    appName: APP_NAME,
+                    sender: SENDER,
+                    layout,
+                    transactions: [basicTx().serialize()],
+                } as any as SignTransactionRequest)).toThrow('Invalid selected layout');
+            }
+        });
+
+        it('rejects a legacy single-transaction request with a staking layout by transaction count', () => {
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                recipient: RECIPIENT,
+                value: 12345,
+                validityStartHeight: VALIDITY_START_HEIGHT,
+                layout: 'unstaking',
+                validatorAddress: VALIDATOR,
+            } as any as SignTransactionRequest)).toThrow('unstaking layout requires exactly three transactions');
+        });
+    });
+
+    describe('serialized transaction entries', () => {
+        it('rejects garbage bytes', () => {
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [new Uint8Array([1, 2, 3])],
+            })).toThrow();
+        });
+
+        it('rejects a transaction whose sender matches its recipient', () => {
+            const tx = new Nimiq.Transaction(
+                address(SENDER), Nimiq.AccountType.Basic, new Uint8Array(0),
+                address(SENDER), Nimiq.AccountType.Basic, new Uint8Array(0),
+                BigInt(100000), BigInt(0), Nimiq.TransactionFlag.None, VALIDITY_START_HEIGHT, networkId(),
+            );
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [tx.serialize()],
+            })).toThrow('Sender and recipient must not match');
+        });
+
+        it('rejects a transaction of a different network', () => {
+            const tx = basicTx(SENDER, RECIPIENT, VALIDITY_START_HEIGHT, networkId() === 5 ? 24 : 5);
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [tx.serialize()],
+            })).toThrow('Wrong transaction network');
+        });
+    });
+
+    describe('transaction info object entries', () => {
+        it('inherits the request-level sender and defaults to a basic sender', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: RECIPIENT,
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            });
+            const [tx] = parsed.transactions;
+            expect(tx.sender.toUserFriendlyAddress()).toBe(SENDER);
+            expect(tx.senderType).toBe(Nimiq.AccountType.Basic);
+            expect(tx.fee).toBe(BigInt(0));
+        });
+
+        it('supports mixed serialized and object entries', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [
+                    basicTx().serialize(),
+                    {
+                        recipient: OTHER,
+                        value: 100000,
+                        validityStartHeight: VALIDITY_START_HEIGHT,
+                    },
+                ],
+            });
+            expect(parsed.transactions.length).toBe(2);
+            expect(parsed.transactions[1].sender.toUserFriendlyAddress()).toBe(SENDER);
+        });
+
+        it('rejects invalid sender and recipient types', () => {
+            const base = {
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: RECIPIENT,
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            };
+            expect(() => parseSignTransactionRequest({
+                ...base,
+                transactions: [{ ...base.transactions[0], senderType: 99 }],
+            } as any as SignTransactionRequest)).toThrow('Invalid sender type');
+            expect(() => parseSignTransactionRequest({
+                ...base,
+                transactions: [{ ...base.transactions[0], recipientType: 99 }],
+            } as any as SignTransactionRequest)).toThrow('Invalid recipient type');
+        });
+
+        it('utf8-encodes string recipientData', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: RECIPIENT,
+                    recipientData: 'hi',
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            });
+            expect(Array.from(parsed.transactions[0].data)).toEqual([104, 105]);
+        });
+
+        it('caps recipientData at 64 bytes for non-staking recipients', () => {
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: RECIPIENT,
+                    recipientData: new Uint8Array(65),
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            })).toThrow('Data must not exceed 64 bytes');
+        });
+
+        it('does not apply the 64 byte cap for staking recipients', () => {
+            // Use real update-staker recipient data (> 64 bytes including the zeroed staking proof placeholder)
+            // to also cover expressing a staking transaction as an object entry.
+            const [, updateStakerTx] = switchValidatorTxs();
+            expect(updateStakerTx.data.byteLength).toBeGreaterThan(64);
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: updateStakerTx.recipient.toUserFriendlyAddress(),
+                    recipientType: Nimiq.AccountType.Staking,
+                    recipientData: updateStakerTx.data,
+                    value: 0,
+                    flags: updateStakerTx.flags,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            });
+            expect(Array.from(parsed.transactions[0].data)).toEqual(Array.from(updateStakerTx.data));
+        });
+
+        it('accepts contract creations via the CONTRACT_CREATION pseudo recipient', () => {
+            // Nimiq.Transaction derives the created contract's address from the other transaction parameters and
+            // replaces whatever recipient is passed to it with that address, which is why contract creations must
+            // not specify a recipient. Building the reference transaction with a recipient address different to
+            // the placeholder address the parsing passes pins that neither ends up in the parsed transaction.
+            for (const [recipientType, byteLength] of [
+                [Nimiq.AccountType.HTLC, 82],
+                [Nimiq.AccountType.Vesting, 28],
+                [Nimiq.AccountType.Vesting, 44],
+                [Nimiq.AccountType.Vesting, 52],
+            ] as Array<[Nimiq.AccountType, number]>) {
+                const recipientData = new Uint8Array(byteLength);
+                const parsed = parseSignTransactionRequest({
+                    appName: APP_NAME,
+                    sender: SENDER,
+                    transactions: [{
+                        recipient: 'CONTRACT_CREATION',
+                        recipientType,
+                        recipientData,
+                        flags: Nimiq.TransactionFlag.ContractCreation,
+                        value: 100000,
+                        validityStartHeight: VALIDITY_START_HEIGHT,
+                    }],
+                });
+                const reference = new Nimiq.Transaction(
+                    address(SENDER), Nimiq.AccountType.Basic, new Uint8Array(0),
+                    address(OTHER), recipientType, recipientData,
+                    BigInt(100000), BigInt(0), Nimiq.TransactionFlag.ContractCreation,
+                    VALIDITY_START_HEIGHT, networkId(),
+                );
+                const [transaction] = parsed.transactions;
+                expect(transaction.flags).toBe(Nimiq.TransactionFlag.ContractCreation);
+                expect(transaction.recipient.toUserFriendlyAddress())
+                    .toBe(reference.recipient.toUserFriendlyAddress());
+                expect(transaction.recipient.toUserFriendlyAddress()).not.toBe(OTHER);
+                expect(Array.from(transaction.serialize())).toEqual(Array.from(reference.serialize()));
+            }
+        });
+
+        it('rejects contract creations with a recipient address', () => {
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: RECIPIENT,
+                    recipientType: Nimiq.AccountType.HTLC,
+                    recipientData: new Uint8Array(82),
+                    flags: Nimiq.TransactionFlag.ContractCreation,
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            })).toThrow('Transaction recipient must be "CONTRACT_CREATION" when creating contracts');
+        });
+
+        it('rejects the CONTRACT_CREATION pseudo recipient without the contract creation flag', () => {
+            // Without this check, the placeholder address passed to Nimiq.Transaction for the pseudo recipient
+            // would end up in the transaction as an actual recipient, sending the funds to the burn address.
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: 'CONTRACT_CREATION',
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            })).toThrow('Transaction recipient can only be "CONTRACT_CREATION" when creating contracts');
+        });
+
+        it('rejects contract creation data of invalid length', () => {
+            for (const byteLength of [0, 27, 29, 43, 81, 83]) {
+                expect(() => parseSignTransactionRequest({
+                    appName: APP_NAME,
+                    sender: SENDER,
+                    transactions: [{
+                        recipient: 'CONTRACT_CREATION',
+                        recipientType: Nimiq.AccountType.HTLC,
+                        recipientData: new Uint8Array(byteLength),
+                        flags: Nimiq.TransactionFlag.ContractCreation,
+                        value: 100000,
+                        validityStartHeight: VALIDITY_START_HEIGHT,
+                    }],
+                })).toThrow('Contract creation data must be 82 bytes for HTLC and 28, 44, or 52 bytes for vesting '
+                    + 'contracts');
+            }
+        });
+
+        it('rejects flags that are not a single known flag', () => {
+            // Nimiq.Transaction truncates fractional flags and flags exceeding a byte, and normalizes the contract
+            // creation flag combined with the signaling flag to plain contract creation, in each case replacing
+            // the requested recipient with the created contract's address, such that these values would pass the
+            // checks above as a substitute for the plain contract creation flag.
+            const contractCreationFlags = Nimiq.TransactionFlag.ContractCreation;
+            for (const flags of [
+                contractCreationFlags | Nimiq.TransactionFlag.Signaling, // tslint:disable-line no-bitwise
+                1.5, // truncated to ContractCreation
+                257, // truncated to ContractCreation
+            ]) {
+                expect(() => parseSignTransactionRequest({
+                    appName: APP_NAME,
+                    sender: SENDER,
+                    transactions: [{
+                        recipient: RECIPIENT,
+                        recipientType: Nimiq.AccountType.HTLC,
+                        recipientData: new Uint8Array(82),
+                        flags,
+                        value: 100000,
+                        validityStartHeight: VALIDITY_START_HEIGHT,
+                    }],
+                })).toThrow('Combined flags are not supported for transaction entries');
+            }
+        });
+
+        it('rejects addresses that are not addresses', () => {
+            // The Nimiq.Address constructor converts array-likes into an arbitrary address instead of rejecting
+            // them; for example new Nimiq.Address({length: 20}) yields the zero address.
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [{
+                    recipient: { length: 20 },
+                    value: 100000,
+                    validityStartHeight: VALIDITY_START_HEIGHT,
+                }],
+            } as any as SignTransactionRequest)).toThrow('recipient must be a valid Nimiq address');
+        });
+    });
+
+    describe('aggregate and ordering checks', () => {
+        it('rejects total values above Number.MAX_SAFE_INTEGER', () => {
+            const half = BigInt('5000000000000000'); // 5e15; two of these exceed MAX_SAFE_INTEGER (~9e15)
+            const transactions = [RECIPIENT, OTHER].map((recipient, i) => new Nimiq.Transaction(
+                address(SENDER), Nimiq.AccountType.Basic, new Uint8Array(0),
+                address(recipient), Nimiq.AccountType.Basic, new Uint8Array(0),
+                half, BigInt(0), Nimiq.TransactionFlag.None, VALIDITY_START_HEIGHT + i, networkId(),
+            ).serialize());
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions,
+            })).toThrow('Total value or fee across transactions exceeds safe integer limit');
+        });
+
+        it('rejects transactions with decreasing validity start heights', () => {
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [
+                    basicTx(SENDER, RECIPIENT, 100).serialize(),
+                    basicTx(SENDER, OTHER, 50).serialize(),
+                ],
+            })).toThrow('Transactions must be valid in order');
+        });
+    });
+
+    describe('staker proofs and sender binding', () => {
+        it('rejects incoming staking transactions with a user-provided staking proof', () => {
+            const [setActiveStakeTx, updateStakerTx] = switchValidatorTxs();
+            const keyPair = Nimiq.KeyPair.derive(new Nimiq.PrivateKey(new Uint8Array([
+                70, 207, 252, 77, 192, 84, 237, 202, 3, 46, 88, 64, 101, 200, 131, 19, 212,
+                105, 128, 49, 54, 99, 159, 166, 103, 196, 208, 178, 26, 244, 184, 234,
+            ])));
+            updateStakerTx.sign(keyPair, keyPair); // fills the staking proof in the recipient data
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest([setActiveStakeTx, updateStakerTx]),
+            )).toThrow('Staking transactions with a user-provided signature proof are not supported');
+        });
+
+        it('accepts incoming staking transactions with the zeroed placeholder proof', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs()),
+            )).not.toThrow();
+        });
+
+        it('rejects transactions with a sender other than the request sender', () => {
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [basicTx(OTHER, RECIPIENT).serialize()],
+            })).toThrow('Transaction sender must match request sender');
+        });
+
+        it('rejects transactions from a contract other than the request sender', () => {
+            // The signing key is resolved from the request sender only - for a contract sender that is the
+            // contract's owner - so a transaction from another sender, which the user may well be able to sign
+            // for, must not ride along with a request for a different sender.
+            const contractTx = new Nimiq.Transaction(
+                address(OTHER), Nimiq.AccountType.Vesting, new Uint8Array(0),
+                address(RECIPIENT), Nimiq.AccountType.Basic, new Uint8Array(0),
+                BigInt(100000), BigInt(0), Nimiq.TransactionFlag.None, VALIDITY_START_HEIGHT, networkId(),
+            );
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [basicTx().serialize(), contractTx.serialize()],
+            })).toThrow('Transaction sender must match request sender');
+        });
+
+        it('accepts transactions from a contract that is the request sender', () => {
+            // Sending from one's own vesting or HTLC contract is supported; the request sender is then the
+            // contract, for which the views resolve the contract's owner as the signer.
+            const contractTx = new Nimiq.Transaction(
+                address(SENDER), Nimiq.AccountType.Vesting, new Uint8Array(0),
+                address(RECIPIENT), Nimiq.AccountType.Basic, new Uint8Array(0),
+                BigInt(100000), BigInt(0), Nimiq.TransactionFlag.None, VALIDITY_START_HEIGHT, networkId(),
+            );
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [contractTx.serialize()],
+            });
+            expect(parsed.transactions[0].senderType).toBe(Nimiq.AccountType.Vesting);
+        });
+
+        it('rejects outgoing staking transactions that do not pay out to the request sender', () => {
+            // An outgoing staking transaction is sent from the staking contract and is therefore bound to the
+            // request sender via its payout address instead.
+            const removeStakeTx = Nimiq.TransactionBuilder.newRemoveStake(
+                address(OTHER), BigInt(100000), BigInt(0), VALIDITY_START_HEIGHT, networkId(),
+            );
+            expect(() => parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [removeStakeTx.serialize()],
+            })).toThrow('Outgoing staking transactions must pay out to the request sender');
+        });
+
+        it('rejects staking layout transactions whose fee-payer is not the request sender', () => {
+            // The layout's own same-fee-payer check is unreachable here, as both senders are individually bound
+            // to the request sender; the binding is what fires.
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ updateStakerSender: OTHER })),
+            )).toThrow('Transaction sender must match request sender');
+        });
+    });
+
+    describe('standard layout labels', () => {
+        it('parses the recipient label for a single transaction', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [basicTx().serialize()],
+                recipientLabel: 'You',
+            });
+            expect(parsed.recipientLabel).toBe('You');
+        });
+
+        it('does not accept a requested label for the user\'s own sender account', () => {
+            // A caller must not be able to relabel the user's own account, for example as a well-known account,
+            // on the confirmation screens; the label is taken from the user's account data in the views.
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [basicTx().serialize()],
+                senderLabel: 'Nimiq Foundation Cold Wallet',
+            } as any as SignTransactionRequest);
+            expect(parsed.senderLabel).toBeUndefined();
+        });
+
+        it('does not accept a requested label for a recipient that is the user\'s own address', () => {
+            // Outgoing staking transactions, e.g. remove-stake, are sent from the staking contract and pay out to
+            // the request sender, i.e. the user's own account is the recipient, which a caller must not be able to
+            // relabel. The label is taken from the user's account data in the views.
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [payoutToUserTx().serialize()],
+                recipientLabel: 'Shop XYZ Payment',
+            });
+            expect(parsed.transactions[0].senderType).toBe(Nimiq.AccountType.Staking);
+            expect(parsed.transactions[0].recipient.toUserFriendlyAddress()).toBe(SENDER);
+            expect(parsed.recipientLabel).toBeUndefined();
+        });
+
+        it('ignores labels for multiple transactions', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [
+                    basicTx(SENDER, RECIPIENT).serialize(),
+                    basicTx(SENDER, OTHER).serialize(),
+                ],
+                recipientLabel: 'You',
+            });
+            expect(parsed.senderLabel).toBeUndefined();
+            expect(parsed.recipientLabel).toBeUndefined();
+        });
+
+        it('rejects overlong labels and labels with control characters', () => {
+            const base = {
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [basicTx().serialize()],
+            };
+            expect(() => parseSignTransactionRequest({
+                ...base,
+                recipientLabel: 'x'.repeat(64),
+            })).toThrow('recipientLabel must not exceed 63 bytes');
+            expect(() => parseSignTransactionRequest({
+                ...base,
+                recipientLabel: 'new\nline',
+            })).toThrow('Label cannot contain control characters');
+        });
+    });
+
+    describe('switch-validator layout', () => {
+        it('parses a valid request and derives the validator from the signed newDelegation', () => {
+            const parsed = parseSignTransactionRequest(switchValidatorRequest(switchValidatorTxs(), {
+                senderLabel: 'From Validator',
+                recipientLabel: 'To Validator',
+                // A request-provided validatorAddress must not influence the derived one.
+                validatorAddress: OTHER,
+                validatorImageUrl: 'https://example.com/validator.png',
+                fromValidatorImageUrl: 'https://example.com/from-validator.png',
+            }));
+            expect(parsed.layout).toBe('switch-validator');
+            expect(parsed.validatorAddress!.toUserFriendlyAddress()).toBe(VALIDATOR);
+            expect(parsed.fromValidatorAddress!.toUserFriendlyAddress()).toBe(FROM_VALIDATOR);
+            expect(parsed.senderLabel).toBe('From Validator');
+            expect(parsed.recipientLabel).toBe('To Validator');
+            expect(parsed.validatorImageUrl!.toString()).toBe('https://example.com/validator.png');
+        });
+
+        it('accepts an update-staker delay of exactly two epochs', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ updateStakerDelay: 2 * epoch() })),
+            )).not.toThrow();
+        });
+
+        it('does not accept a requested label for the user\'s own staking address', () => {
+            // The stake belongs to the user's own address; same as for the standard layout's sender, a caller must
+            // not be able to relabel it. The label is taken from the user's account data in the views.
+            const parsed = parseSignTransactionRequest(switchValidatorRequest(switchValidatorTxs(), {
+                stakerLabel: 'My Stake',
+            }));
+            expect((parsed as any).stakerLabel).toBeUndefined();
+        });
+
+        it('rejects transaction counts other than two', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest([switchValidatorTxs()[0]]),
+            )).toThrow('switch-validator layout requires exactly two transactions');
+        });
+
+        it('rejects contract senders', () => {
+            const [setActiveStakeTx, updateStakerTx] = switchValidatorTxs();
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest([withContractSender(setActiveStakeTx), updateStakerTx]),
+            )).toThrow('switch-validator transaction sender must not be a contract');
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest([setActiveStakeTx, withContractSender(updateStakerTx)]),
+            )).toThrow('switch-validator transaction sender must not be a contract');
+        });
+
+        it('rejects wrong transaction data types', () => {
+            const [setActiveStakeTx] = switchValidatorTxs();
+            const secondSetActiveStakeTx = Nimiq.TransactionBuilder.newSetActiveStake(
+                address(SENDER), BigInt(0), BigInt(0), VALIDITY_START_HEIGHT + epoch() + 1, networkId(),
+            );
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest([setActiveStakeTx, secondSetActiveStakeTx]),
+            )).toThrow('switch-validator transactions must be set-active-stake followed by update-staker');
+        });
+
+        it('rejects set-active-stake transactions that do not deactivate all stake', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ newActiveBalance: BigInt(5) })),
+            )).toThrow('switch-validator set-active-stake must deactivate all stake');
+        });
+
+        it('rejects update-staker transactions without a newDelegation', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ newDelegation: undefined })),
+            )).toThrow('switch-validator update-staker must include a newDelegation');
+        });
+
+        it('rejects update-staker transactions without reactivateAllStake', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ reactivateAllStake: false })),
+            )).toThrow('switch-validator update-staker must have reactivateAllStake set');
+        });
+
+        it('rejects update-staker delays outside of one to two epochs', () => {
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ updateStakerDelay: epoch() })),
+            )).toThrow('switch-validator update-staker must start one to two epochs after set-active-stake');
+            expect(() => parseSignTransactionRequest(
+                switchValidatorRequest(switchValidatorTxs({ updateStakerDelay: 2 * epoch() + 1 })),
+            )).toThrow('switch-validator update-staker must start one to two epochs after set-active-stake');
+        });
+
+        it('requires fromValidatorAddress', () => {
+            expect(() => parseSignTransactionRequest(switchValidatorRequest(switchValidatorTxs(), {
+                fromValidatorAddress: undefined,
+            }))).toThrow('fromValidatorAddress must be a valid Nimiq address');
+        });
+    });
+
+    describe('unstaking layout', () => {
+        it('parses a valid request', () => {
+            const parsed = parseSignTransactionRequest(unstakingRequest(unstakingTxs(), {
+                senderLabel: 'Validator',
+                validatorImageUrl: 'https://example.com/validator.png',
+            }));
+            expect(parsed.layout).toBe('unstaking');
+            expect(parsed.validatorAddress!.toUserFriendlyAddress()).toBe(VALIDATOR);
+            expect(parsed.senderLabel).toBe('Validator');
+            expect(parsed.transactions.length).toBe(3);
+        });
+
+        it('does not accept a requested label for the user\'s own payout address', () => {
+            // The unstaked funds are paid out to the user's own address; same as for the standard layout's sender,
+            // a caller must not be able to relabel it. The label is taken from the user's account data in the views.
+            const parsed = parseSignTransactionRequest(unstakingRequest(unstakingTxs(), {
+                recipientLabel: 'My Address',
+            }));
+            expect(parsed.recipientLabel).toBeUndefined();
+        });
+
+        it('rejects transaction counts other than three', () => {
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest(unstakingTxs().slice(0, 2)),
+            )).toThrow('unstaking layout requires exactly three transactions');
+        });
+
+        it('rejects contract senders', () => {
+            const [setActiveStakeTx, retireStakeTx, removeStakeTx] = unstakingTxs();
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest([withContractSender(setActiveStakeTx), retireStakeTx, removeStakeTx]),
+            )).toThrow('unstaking transaction sender must not be a contract');
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest([setActiveStakeTx, withContractSender(retireStakeTx), removeStakeTx]),
+            )).toThrow('unstaking transaction sender must not be a contract');
+        });
+
+        it('rejects retiring more than is being paid out', () => {
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest(unstakingTxs({ retireStake: BigInt(100001) })),
+            )).toThrow('unstaking must not retire more than is being paid out');
+        });
+
+        it('rejects a payout to an address other than the fee payer and staker', () => {
+            // Note that this is now already caught by the general binding of the transactions to the request
+            // sender; the layout's own payout check, which the Keyguard needs as it has no request-level sender,
+            // is kept as defense in depth and for diffability with the Keyguard.
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest(unstakingTxs({ removeStakeRecipient: OTHER })),
+            )).toThrow('Outgoing staking transactions must pay out to the request sender');
+        });
+
+        it('rejects a payout to a contract', () => {
+            const [setActiveStakeTx, retireStakeTx, removeStakeTx] = unstakingTxs();
+            const contractPayoutTx = new Nimiq.Transaction(
+                removeStakeTx.sender, Nimiq.AccountType.Staking, removeStakeTx.senderData,
+                address(SENDER), Nimiq.AccountType.Vesting, new Uint8Array(0),
+                removeStakeTx.value, removeStakeTx.fee, removeStakeTx.flags,
+                removeStakeTx.validityStartHeight, networkId(),
+            );
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest([setActiveStakeTx, retireStakeTx, contractPayoutTx]),
+            )).toThrow('unstaking transactions must not payout to a contract');
+        });
+
+        it('rejects recipient data on the remove-stake transaction', () => {
+            const [setActiveStakeTx, retireStakeTx, removeStakeTx] = unstakingTxs();
+            const dataPayoutTx = new Nimiq.Transaction(
+                removeStakeTx.sender, Nimiq.AccountType.Staking, removeStakeTx.senderData,
+                address(SENDER), Nimiq.AccountType.Basic, new Uint8Array([1, 2, 3]),
+                removeStakeTx.value, removeStakeTx.fee, removeStakeTx.flags,
+                removeStakeTx.validityStartHeight, networkId(),
+            );
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest([setActiveStakeTx, retireStakeTx, dataPayoutTx]),
+            )).toThrow('unstaking transactions must not have recipient data');
+        });
+
+        it('rejects retire-stake delays outside of one to two epochs', () => {
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest(unstakingTxs({ retireStakeDelay: epoch() })),
+            )).toThrow('unstaking retire-stake must start one to two epochs after set-active-stake');
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest(unstakingTxs({ retireStakeDelay: 2 * epoch() + 1 })),
+            )).toThrow('unstaking retire-stake must start one to two epochs after set-active-stake');
+        });
+
+        it('rejects a remove-stake that does not start one block after retire-stake', () => {
+            expect(() => parseSignTransactionRequest(
+                unstakingRequest(unstakingTxs({ removeStakeDelayAfterRetire: 2 })),
+            )).toThrow('unstaking remove-stake must start one block after retire-stake');
+        });
+
+        it('requires validatorAddress', () => {
+            expect(() => parseSignTransactionRequest(unstakingRequest(unstakingTxs(), {
+                validatorAddress: undefined,
+            }))).toThrow('validatorAddress must be a valid Nimiq address');
+        });
+    });
+
+    describe('raw request export', () => {
+        it('round-trips a legacy single-transaction request through the byte format', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                recipient: RECIPIENT,
+                recipientLabel: 'Alice',
+                value: 12345,
+                fee: 7,
+                extraData: 'hello',
+                validityStartHeight: VALIDITY_START_HEIGHT,
+            });
+            const raw = rawSignTransactionRequest(parsed);
+            expect('transactions' in raw && raw.transactions[0]).toBeInstanceOf(Uint8Array);
+            expectParsedEqual(parseSignTransactionRequest(raw), parsed);
+        });
+
+        it('round-trips a standard multi-transaction request', () => {
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [
+                    basicTx(SENDER, RECIPIENT).serialize(),
+                    {
+                        recipient: OTHER,
+                        value: 100000,
+                        validityStartHeight: VALIDITY_START_HEIGHT,
+                    },
+                ],
+            });
+            expectParsedEqual(parseSignTransactionRequest(rawSignTransactionRequest(parsed)), parsed);
+        });
+
+        it('round-trips a switch-validator request and omits the derived validatorAddress', () => {
+            const parsed = parseSignTransactionRequest(switchValidatorRequest(switchValidatorTxs(), {
+                senderLabel: 'From Validator',
+                recipientLabel: 'To Validator',
+                validatorImageUrl: 'https://example.com/validator.png',
+            }));
+            const raw = rawSignTransactionRequest(parsed);
+            expect('validatorAddress' in raw ? (raw as any).validatorAddress : undefined).toBeUndefined();
+            expectParsedEqual(parseSignTransactionRequest(raw), parsed);
+        });
+
+        it('round-trips an unstaking request including its validatorAddress', () => {
+            const parsed = parseSignTransactionRequest(unstakingRequest(unstakingTxs(), {
+                validatorImageUrl: 'https://example.com/validator.png',
+            }));
+            const raw = rawSignTransactionRequest(parsed);
+            expect((raw as any).validatorAddress).toBe(VALIDATOR);
+            expectParsedEqual(parseSignTransactionRequest(raw), parsed);
+        });
+    });
+
+    describe('patchLegacyRequestSenderType', () => {
+        const legacyRequest = (extraFields: object = {}) => parseSignTransactionRequest({
+            appName: APP_NAME,
+            sender: SENDER,
+            recipient: RECIPIENT,
+            value: 100000,
+            fee: 138,
+            extraData: new Uint8Array([1, 2, 3]),
+            validityStartHeight: VALIDITY_START_HEIGHT,
+            ...extraFields,
+        } as SignTransactionRequest);
+
+        it('applies the WalletStore contract type to a legacy request in place, changing nothing else', () => {
+            const parsed = legacyRequest();
+            const [original] = parsed.transactions;
+            expect(original.senderType).toBe(Nimiq.AccountType.Basic);
+
+            patchLegacyRequestSenderType(parsed, Nimiq.AccountType.Vesting);
+
+            const [patched] = parsed.transactions;
+            expect(patched).not.toBe(original);
+            const reference = new Nimiq.Transaction(
+                address(SENDER), Nimiq.AccountType.Vesting, new Uint8Array(0),
+                address(RECIPIENT), Nimiq.AccountType.Basic, new Uint8Array([1, 2, 3]),
+                BigInt(100000), BigInt(138), Nimiq.TransactionFlag.None, VALIDITY_START_HEIGHT, networkId(),
+            );
+            expect(Array.from(patched.serialize())).toEqual(Array.from(reference.serialize()));
+            // The patched request survives the history state round-trip.
+            expectParsedEqual(parseSignTransactionRequest(rawSignTransactionRequest(parsed)), parsed);
+        });
+
+        it('leaves a legacy request from a basic account untouched', () => {
+            const parsed = legacyRequest();
+            const [original] = parsed.transactions;
+            patchLegacyRequestSenderType(parsed, Nimiq.AccountType.Basic);
+            expect(parsed.transactions[0]).toBe(original);
+        });
+
+        it('keeps an explicitly specified non-basic sender type', () => {
+            const vestingTx = new Nimiq.Transaction(
+                address(SENDER), Nimiq.AccountType.Vesting, new Uint8Array(0),
+                address(RECIPIENT), Nimiq.AccountType.Basic, new Uint8Array(0),
+                BigInt(100000), BigInt(0), Nimiq.TransactionFlag.None, VALIDITY_START_HEIGHT, networkId(),
+            );
+            const parsed = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [vestingTx.serialize()],
+            });
+            const [original] = parsed.transactions;
+            patchLegacyRequestSenderType(parsed, Nimiq.AccountType.HTLC);
+            expect(parsed.transactions[0]).toBe(original);
+            expect(parsed.transactions[0].senderType).toBe(Nimiq.AccountType.Vesting);
+        });
+
+        it('does not apply to multiple transactions or to the staking layouts', () => {
+            const multi = parseSignTransactionRequest({
+                appName: APP_NAME,
+                sender: SENDER,
+                transactions: [basicTx(SENDER, RECIPIENT).serialize(), basicTx(SENDER, OTHER).serialize()],
+            });
+            const [firstMulti, secondMulti] = multi.transactions;
+            patchLegacyRequestSenderType(multi, Nimiq.AccountType.Vesting);
+            expect(multi.transactions[0]).toBe(firstMulti);
+            expect(multi.transactions[1]).toBe(secondMulti);
+
+            const unstaking = parseSignTransactionRequest(unstakingRequest(unstakingTxs()));
+            const [firstUnstaking] = unstaking.transactions;
+            patchLegacyRequestSenderType(unstaking, Nimiq.AccountType.Vesting);
+            expect(unstaking.transactions[0]).toBe(firstUnstaking);
+        });
+
+        it('re-derives the created contract address of a legacy contract creation', () => {
+            // The created contract's address depends on the sender type, and Nimiq.Transaction derives it itself,
+            // see the CONTRACT_CREATION test above. Rebuilding the transaction with the resolved sender type must
+            // therefore result in the address of the contract created by a transaction with that sender type.
+            const parsed = legacyRequest({
+                recipient: 'CONTRACT_CREATION',
+                recipientType: Nimiq.AccountType.Vesting,
+                extraData: new Uint8Array(28),
+                flags: Nimiq.TransactionFlag.ContractCreation,
+            });
+            const basicSenderContractAddress = parsed.transactions[0].recipient.toUserFriendlyAddress();
+
+            patchLegacyRequestSenderType(parsed, Nimiq.AccountType.Vesting);
+
+            const reference = new Nimiq.Transaction(
+                address(SENDER), Nimiq.AccountType.Vesting, new Uint8Array(0),
+                address(OTHER), Nimiq.AccountType.Vesting, new Uint8Array(28),
+                BigInt(100000), BigInt(138), Nimiq.TransactionFlag.ContractCreation, VALIDITY_START_HEIGHT,
+                networkId(),
+            );
+            const [patched] = parsed.transactions;
+            expect(patched.recipient.toUserFriendlyAddress()).toBe(reference.recipient.toUserFriendlyAddress());
+            expect(patched.recipient.toUserFriendlyAddress()).not.toBe(basicSenderContractAddress);
+            expect(Array.from(patched.serialize())).toEqual(Array.from(reference.serialize()));
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,10 +1889,19 @@
   resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.6.4.tgz#2ab36ab6f7d4062c3d534e6da831c2ccaae959de"
   integrity sha512-D0jVukuL+zsUXicS4cCZEPlBzlzBe0D1sNWecEhaSjTR1iMa9f+fA9l08wlQtRVw96Z6yHRgQokWVnO1GcWI7Q==
 
-"@nimiq/core@^2.1.1", "@nimiq/core@^2.2.2", "@nimiq/core@^2.20.0":
+"@nimiq/core@^2.2.2", "@nimiq/core@^2.20.0":
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/@nimiq/core/-/core-2.20.0.tgz#c923cfbfedc53d00d3be235e6c1b281e10c51323"
   integrity sha512-JJYQJRVoI61rulUbeMH83HPv3o+vfaivjk93t50YbYTo5QY4zx/yrpmX1Xsvjk3i2nszaC6iql22g7CPd4tUSQ==
+  dependencies:
+    comlink "^4.4.1"
+    vite-plugin-wasm "^3.5.0"
+    websocket "^1.0.34"
+
+"@nimiq/core@^2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/core/-/core-2.21.0.tgz#99d257cb842658082fe39ed350e3521bca3036ae"
+  integrity sha512-CBWMQhnFSQ8tEqRc3FThq4XaUIf83+KSkoOYPfkzx9kR1dne3ihztUqqxJkZ6ff6onl2AG4S6atL0sFjms0cjQ==
   dependencies:
     comlink "^4.4.1"
     vite-plugin-wasm "^3.5.0"
@@ -1916,14 +1925,15 @@
   dependencies:
     dom-parser "^0.1.5"
 
-"@nimiq/keyguard-client@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-1.10.0.tgz#7d2a8933cd574d8f2dbe4adde1e3402ec56666a9"
-  integrity sha512-yn9wL/Z0Zzwn5O8CvIkCfz6bEVRhzfZ/bY2hSNmdCFnIfNfCfVPE9D/ENtLWmngI59xJeugduVXnw9PAoy5nNA==
+"@nimiq/keyguard-client@^1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-1.11.1.tgz#5c557fb5e15a656312fcbfe1731f6a45af867e18"
+  integrity sha512-LZXV5bd33xdGVz7RxRQDNSa0b/iBryxlKzNXI6NEpEe8cyn2LOkOrKsTuajQlrjOFbxuPX7GrUVcwxweK3McDw==
   dependencies:
-    "@nimiq/core" "^2.1.1"
+    "@nimiq/core" "^2.21.0"
     "@nimiq/rpc" "^0.3.0"
     "@opengsn/common" "^2.2.5"
+    patch-package "^8.0.1"
 
 "@nimiq/ledger-api@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
### Why

Unstaking and switching validators need **several transactions signed in one user interaction**, because
the later ones can only be broadcast after the first has settled on chain — they are then handed to the
watchtower, which sends them when the deactivation matures. `SIGN_TRANSACTION` could only ever carry one
transaction, so the Hub had no way to express the request or to drive a Ledger through several consecutive
signatures.

This is the Hub half. The Keyguard half is T404-16; the wallet half is its own branch.

### What

**Client API** — `client/PublicRequestTypes.ts`, `client/HubApi.ts`

- `SignTransactionRequest` becomes a union of four shapes, with the existing inline single-transaction
  request kept unchanged as `SignTransactionRequestSingle` for backward compatibility:
  - `standard` — a `transactions` array of `TransactionInfo` entries or serialized `Uint8Array`s
  - `switch-validator` — exactly two: set-active-stake, update-staker
  - `unstaking` — exactly three: set-active-stake, retire-stake, remove-stake
- New `TransactionInfo` entry type mirrors the Keyguard's, minus the sender: the **request-level `sender`
  is inherited by every entry**. As in the Keyguard, entries carry no labels; labels stay request-level and
  only apply when there is a single transaction.
- `signTransaction()` now resolves to `SignedTransaction | SignedTransaction[]` — an array exactly when
  more than one transaction was signed.
- `switch-validator` deliberately has **no `validatorAddress`**: the target is derived from the signed
  update-staker's `newDelegation`, so what is displayed is what gets signed. `SignStakingRequest` gains the
  validator address/image and amount fields the wallet needs to render both sides of a switch.

**Request parsing** — new `src/lib/SignTransactionRequestParsing.ts` (703 lines)

- A close port of the Keyguard's request parsing, kept diffable against it check for check, with every
  deviation marked in a comment. This matters because **for Ledger accounts there is no Keyguard**, so
  this parsing plus the Ledger's own display is the only validation the request gets.
- Layout constraints are enforced at parse time (transaction kind and order per layout), along with
  sender/recipient, network id, staking data and label checks.
- Deliberately free of app-graph imports (`RpcApi`, router, views) so it can be imported standalone by
  unit tests — new `tests/unit/SignTransactionRequestParsing.spec.ts`, 65 tests over 1020 lines.
- `rawSignTransactionRequest()` is the inverse mapping for history state, preserving layout and validator
  metadata across a redirect.

**Ledger** — `src/views/SignTransactionLedger.vue` (largely rewritten), `src/components/LedgerUi.vue`

- Arbitrary multi-transaction standard requests, plus the two staking layouts, signed as consecutive Ledger
  interactions.
- A multi-step signing indicator: a checkmark per completed step, the current step number and its
  instructions, pending steps after it — collapsing to a compact `n/total` counter above 8 steps.
- Both validators rendered for a switch, the validator shown on the staking-contract side, zero amounts of
  signalling transactions no longer displayed, and a fix for the network client being unavailable on
  Checkout reload.

**Elsewhere** — `SignTransaction.vue` / `SignStaking.vue` / `SignTransactionSuccess.vue` follow the union
type; `RequestParser` and `RequestTypes` carry the `layout` through; `Cashlink` now uses `cashlink.fee` for
funding as well; multi-transaction signing demos added under `demos/`.

### How it was verified

65 new unit tests on the request parsing. QA then ran the ten-flow test plan on T404-15 for both Keyguard
and Ledger (regular send, validator switch, unstaking, instant payout, start staking, add stake, cashlink
creation, swap refund, standard multi-tx signing, checkout):
https://app.qase.io/public/report/379bd6f17c667627377c8950bcb27604cd5e0505

### Follow-ups

- Released as HubApi v1.15.0 on `master`, after this branch.
- `TransactionInfo.validityStartHeight` stays required until the Hub has its own network connection.